### PR TITLE
tpch: speed up data loading

### DIFF
--- a/tpch/dbgen/driver.go
+++ b/tpch/dbgen/driver.go
@@ -112,7 +112,7 @@ func DbGen(loaders map[Table]Loader) error {
 			rowCnt *= scale
 		}
 		if err := genTbl(i, 1, rowCnt); err != nil {
-			return fmt.Errorf("fail to generate %s, err: %v\n", tDefs[i].name, err)
+			return fmt.Errorf("fail to generate %s, err: %v", tDefs[i].name, err)
 		}
 	}
 	return nil

--- a/tpch/dbgen/order_line.go
+++ b/tpch/dbgen/order_line.go
@@ -11,9 +11,6 @@ func (o orderLineLoader) Load(item interface{}) error {
 	if err := tDefs[TOrder].loader.Load(item); err != nil {
 		return err
 	}
-	if err := tDefs[TOrder].loader.Flush(); err != nil {
-		return nil
-	}
 	if err := tDefs[TLine].loader.Load(item); err != nil {
 		return err
 	}
@@ -21,6 +18,9 @@ func (o orderLineLoader) Load(item interface{}) error {
 }
 
 func (o orderLineLoader) Flush() error {
+	if err := tDefs[TOrder].loader.Flush(); err != nil {
+		return nil
+	}
 	if err := tDefs[TLine].loader.Flush(); err != nil {
 		return err
 	}

--- a/tpch/dbgen/part_psupp.go
+++ b/tpch/dbgen/part_psupp.go
@@ -6,9 +6,6 @@ func (p partPsuppLoader) Load(item interface{}) error {
 	if err := tDefs[TPart].loader.Load(item); err != nil {
 		return err
 	}
-	if err := tDefs[TPart].loader.Flush(); err != nil {
-		return err
-	}
 	if err := tDefs[TPsupp].loader.Load(item); err != nil {
 		return err
 	}
@@ -16,6 +13,9 @@ func (p partPsuppLoader) Load(item interface{}) error {
 }
 
 func (p partPsuppLoader) Flush() error {
+	if err := tDefs[TPart].loader.Flush(); err != nil {
+		return err
+	}
 	if err := tDefs[TPsupp].loader.Flush(); err != nil {
 		return err
 	}

--- a/tpch/ddl.go
+++ b/tpch/ddl.go
@@ -65,8 +65,7 @@ CREATE TABLE IF NOT EXISTS supplier (
     S_PHONE CHAR(15) NOT NULL,
     S_ACCTBAL DECIMAL(15, 2) NOT NULL,
     S_COMMENT VARCHAR(101) NOT NULL,
-    PRIMARY KEY (S_SUPPKEY),
-    CONSTRAINT FOREIGN KEY SUPPLIER_FK1 (S_NATIONKEY) references nation(N_NATIONKEY)
+    PRIMARY KEY (S_SUPPKEY)
 )`
 	if err := w.createTableDDL(ctx, query, "supplier", "creating"); err != nil {
 		return err
@@ -79,9 +78,7 @@ CREATE TABLE IF NOT EXISTS partsupp (
     PS_AVAILQTY BIGINT NOT NULL,
     PS_SUPPLYCOST DECIMAL(15, 2) NOT NULL,
     PS_COMMENT VARCHAR(199) NOT NULL,
-    PRIMARY KEY (PS_PARTKEY, PS_SUPPKEY),
-    CONSTRAINT FOREIGN KEY PARTSUPP_FK1 (PS_SUPPKEY) references supplier(S_SUPPKEY),
-    CONSTRAINT FOREIGN KEY PARTSUPP_FK2 (PS_PARTKEY) references part(P_PARTKEY)
+    PRIMARY KEY (PS_PARTKEY, PS_SUPPKEY)
 )`
 	if err := w.createTableDDL(ctx, query, "partsupp", "creating"); err != nil {
 		return err
@@ -97,8 +94,7 @@ CREATE TABLE IF NOT EXISTS customer (
     C_ACCTBAL DECIMAL(15, 2) NOT NULL,
     C_MKTSEGMENT CHAR(10) NOT NULL,
     C_COMMENT VARCHAR(117) NOT NULL,
-    PRIMARY KEY (C_CUSTKEY),
-    CONSTRAINT FOREIGN KEY CUSTOMER_FK1 (C_NATIONKEY) references nation(N_NATIONKEY)
+    PRIMARY KEY (C_CUSTKEY)
 )`
 	if err := w.createTableDDL(ctx, query, "customer", "creating"); err != nil {
 		return err
@@ -115,8 +111,7 @@ CREATE TABLE IF NOT EXISTS orders (
     O_CLERK CHAR(15) NOT NULL,
     O_SHIPPRIORITY BIGINT NOT NULL,
     O_COMMENT VARCHAR(79) NOT NULL,
-    PRIMARY KEY (O_ORDERKEY),
-    CONSTRAINT FOREIGN KEY ORDERS_FK1 (O_CUSTKEY) references customer(C_CUSTKEY)
+    PRIMARY KEY (O_ORDERKEY)
 )`
 	if err := w.createTableDDL(ctx, query, "orders", "creating"); err != nil {
 		return err
@@ -140,9 +135,7 @@ CREATE TABLE IF NOT EXISTS lineitem (
     L_SHIPINSTRUCT CHAR(25) NOT NULL,
     L_SHIPMODE CHAR(10) NOT NULL,
     L_COMMENT VARCHAR(44) NOT NULL,
-    PRIMARY KEY (L_ORDERKEY, L_LINENUMBER),
-    CONSTRAINT FOREIGN KEY LINEITEM_FK1 (L_ORDERKEY) references orders(O_ORDERKEY),
-    CONSTRAINT FOREIGN KEY LINEITEM_FK2 (L_PARTKEY, L_SUPPKEY) references partsupp(PS_PARTKEY, PS_SUPPKEY)
+    PRIMARY KEY (L_ORDERKEY, L_LINENUMBER)
 )
 `
 	if err := w.createTableDDL(ctx, query, "lineitem", "creating"); err != nil {

--- a/tpch/query.go
+++ b/tpch/query.go
@@ -413,6 +413,7 @@ create view revenue0 (supplier_no, total_revenue) as
 		and l_shipdate < date_add('1997-07-01', interval '3' month)
 	group by
 		l_suppkey;
+
 select
 	s_suppkey,
 	s_name,

--- a/tpch/workload.go
+++ b/tpch/workload.go
@@ -49,7 +49,7 @@ func (w *Workloader) getState(ctx context.Context) *tpchState {
 
 func (w *Workloader) updateState(ctx context.Context) {
 	s := w.getState(ctx)
-	s.queryIdx ++
+	s.queryIdx++
 }
 
 // Name return workloader name
@@ -136,7 +136,7 @@ func (w Workloader) Cleanup(ctx context.Context, threadID int) error {
 	return w.dropTable(ctx)
 }
 
-// Check checks data 
+// Check checks data
 func (w Workloader) Check(ctx context.Context, threadID int) error {
 	return nil
 }


### PR DESCRIPTION
Because of `CONSTRAINT FOREIGN KEY` of some tables, rows of the `orders` table need to be inserted before all related lineItems, so they weren't enable to be inserted by batch.

To speed up data loading, I modified some DDLs and removed these foreign key constraints.

PTAL @zhouqiang-cl 