### PR TITLE
make check faster and remove unnecessary index

### DIFF
--- a/tpcc/check.go
+++ b/tpcc/check.go
@@ -358,17 +358,17 @@ func (w *Workloader) checkCondition10(ctx context.Context, warehouse int) error 
 					   AND OL_D_ID = O_D_ID 
 					   AND OL_O_ID = O_ID 
 					   AND OL_DELIVERY_D IS NOT NULL 
-					   AND O_W_ID=c.c_w_id 
+					   AND O_W_ID=? 
 					   AND O_D_ID=c.C_D_ID 
 					   AND O_C_ID=c.C_ID) sm, (SELECT  sum(h_amount)  from  history 
-												WHERE H_C_W_ID=c.C_W_ID 
+												WHERE H_C_W_ID=? 
 												  AND H_C_D_ID=c.C_D_ID 
 												  AND H_C_ID=c.C_ID) smh 
 			 FROM customer c 
 			WHERE  c.c_w_id = ? ) t
    WHERE c1<>sm-smh`
 
-	rows, err := s.Conn.QueryContext(ctx, query, warehouse)
+	rows, err := s.Conn.QueryContext(ctx, query, warehouse, warehouse, warehouse)
 	if err != nil {
 		return fmt.Errorf("Exec %s failed %v", query, err)
 	}
@@ -440,9 +440,9 @@ func (w *Workloader) checkCondition12(ctx context.Context, warehouse int) error 
 	query := `SELECT count(*) FROM (SELECT  c.c_id, c.c_d_id, c.c_balance c1, c_ytd_payment, 
 		(SELECT sum(ol_amount) FROM orders STRAIGHT_JOIN order_line 
 		WHERE OL_W_ID=O_W_ID AND OL_D_ID = O_D_ID AND OL_O_ID = O_ID AND OL_DELIVERY_D IS NOT NULL AND 
-		O_W_ID=c.c_w_id AND O_D_ID=c.C_D_ID AND O_C_ID=c.C_ID) sm FROM customer c WHERE  c.c_w_id = ?) t1 
+		O_W_ID=? AND O_D_ID=c.C_D_ID AND O_C_ID=c.C_ID) sm FROM customer c WHERE  c.c_w_id = ?) t1 
 		WHERE c1+c_ytd_payment <> sm`
-	rows, err := s.Conn.QueryContext(ctx, query, warehouse)
+	rows, err := s.Conn.QueryContext(ctx, query, warehouse, warehouse)
 	if err != nil {
 		return fmt.Errorf("Exec %s failed %v", query, err)
 	}

--- a/tpcc/ddl.go
+++ b/tpcc/ddl.go
@@ -112,9 +112,7 @@ CREATE TABLE IF NOT EXISTS history (
 	h_date DATETIME,
 	h_amount DECIMAL(6, 2),
 	h_data VARCHAR(24),
-	PRIMARY KEY(h_w_id, row_id),
-	INDEX idx_history_customer (h_c_w_id, h_c_d_id, h_c_id),
-	INDEX idx_history_district (h_w_id, h_d_id)
+	PRIMARY KEY(h_w_id, row_id)
 )`
 
 	query = w.appendPartition(query, "h_w_id")
@@ -168,8 +166,7 @@ CREATE TABLE IF NOT EXISTS orders (
 		ol_quantity INT,
 		ol_amount DECIMAL(6, 2),
 		ol_dist_info CHAR(24),
-		PRIMARY KEY(ol_w_id, ol_d_id, ol_o_id, ol_number),
-		INDEX idx_order_line_stock (ol_supply_w_id, ol_d_id)
+		PRIMARY KEY(ol_w_id, ol_d_id, ol_o_id, ol_number)
 )`
 
 	query = w.appendPartition(query, "ol_w_id")
@@ -196,8 +193,7 @@ CREATE TABLE IF NOT EXISTS stock (
 	s_order_cnt INT, 
 	s_remote_cnt INT,
 	s_data VARCHAR(50),
-	PRIMARY KEY(s_w_id, s_i_id),
-	INDEX idx_stock_item (s_i_id)
+	PRIMARY KEY(s_w_id, s_i_id)
 )`
 
 	query = w.appendPartition(query, "s_w_id")


### PR DESCRIPTION
The constant is not propagated correctly for some check SQLs, the check for a single warehouse would scan all the warehouses in the table.

So we pass it manually to get away with this issue.

The check time goes down from 96s to 20s for 10 warehouses, the improvement would be large if we have more warehouses.

Also removed some indices because they are not used.