### PR TITLE
Support csv file in data preparing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ make
 ./bin/go-tpc tpcc --warehouses 4 cleanup
 # Check consistency 
 ./bin/go-tpc tpcc --warehouses 4 check
+# Generate csv files
+./bin/go-tpc tpcc --warehouses 4 prepare --csv.output data
+# Specified tables when generating csv files
+./bin/go-tpc tpcc --warehouses 4 prepare --csv.output data --csv.table history --csv.table orders
 ```
 
 ## TPC-H

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -69,7 +69,7 @@ func main() {
 	rootCmd.PersistentFlags().IntVarP(&port, "port", "P", 4000, "Database port")
 	rootCmd.PersistentFlags().IntVarP(&threads, "threads", "T", 16, "Thread concurrency")
 	rootCmd.PersistentFlags().StringVarP(&driver, "driver", "d", "", "Database driver: mysql")
-	rootCmd.PersistentFlags().DurationVar(&totalTime, "time", 10*time.Minute, "Total execution time")
+	rootCmd.PersistentFlags().DurationVar(&totalTime, "time", 1<<63 - 1, "Total execution time")
 	rootCmd.PersistentFlags().IntVar(&totalCount, "count", 1000000, "Total execution count")
 	rootCmd.PersistentFlags().BoolVar(&dropData, "dropdata", false, "Cleanup data before prepare")
 	rootCmd.PersistentFlags().BoolVar(&ignoreError, "ignore-error", false, "Ignore error when running workload")

--- a/cmd/go-tpc/misc.go
+++ b/cmd/go-tpc/misc.go
@@ -38,7 +38,8 @@ func execute(ctx context.Context, w workload.Workloader, action string, index in
 
 	switch action {
 	case "prepare":
-		if dropData {
+		// Do cleanup only if dropData is set and not generate csv data.
+		if dropData && !w.DataGen() {
 			if err := w.Cleanup(ctx, index); err != nil {
 				return err
 			}

--- a/cmd/go-tpc/misc.go
+++ b/cmd/go-tpc/misc.go
@@ -108,13 +108,17 @@ func executeWorkload(ctx context.Context, w workload.Workloader, action string) 
 	wg.Wait()
 
 	if action == "prepare" {
-		// For prepare, we must check the data consistency after all prepare finished
-		checkPrepare(ctx, w)
+		if !w.DataGen() {
+			// For prepare, we must check the data consistency after all prepare finished
+			checkPrepare(ctx, w)
+		} else {
+			fmt.Println("Skip preparing checking. Please load CSV data into database and check later.")
+		}
 	}
 	outputCancel()
 
 	<-ch
 
-	fmt.Printf("Finished\n")
+	fmt.Println("Finished")
 	measurement.Output()
 }

--- a/cmd/go-tpc/tpcc.go
+++ b/cmd/go-tpc/tpcc.go
@@ -15,13 +15,18 @@ func executeTpcc(action string, args []string) {
 	if tpccConfig.OutputDir == "" {
 		openDB()
 		defer closeDB()
+
+		if len(tpccConfig.Tables) > 0 {
+			fmt.Println("Cannot specify generated tables when csv.output flag not set")
+			os.Exit(1)
+		}
 	}
 
 	tpccConfig.Threads = threads
 	tpccConfig.Isolation = isolationLevel
 	w, err := tpcc.NewWorkloader(globalDB, &tpccConfig)
 	if err != nil {
-		fmt.Printf("failed to init work loader %v\n", err)
+		fmt.Printf("Failed to init work loader: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -40,7 +45,8 @@ func registerTpcc(root *cobra.Command) {
 	cmd.PersistentFlags().IntVar(&tpccConfig.Warehouses, "warehouses", 10, "Number of warehouses")
 	cmd.PersistentFlags().BoolVar(&tpccConfig.CheckAll, "check-all", false, "Run all consistency checks")
 	cmd.PersistentFlags().StringVar(&tpccConfig.OutputDir, "csv.output", "", "Output directory for generating csv file when preparing")
-	// TODO: support specifying only generating one table of csv file.
+	cmd.PersistentFlags().StringArrayVar(&tpccConfig.Tables, "csv.tables", []string{}, "Specified tables to " +
+		"generate in csv file(repeated), valid only if csv.output is set. If not set, generate all tables by default.")
 
 	var cmdPrepare = &cobra.Command{
 		Use:   "prepare",

--- a/cmd/go-tpc/tpcc.go
+++ b/cmd/go-tpc/tpcc.go
@@ -44,9 +44,9 @@ func registerTpcc(root *cobra.Command) {
 	cmd.PersistentFlags().IntVar(&tpccConfig.Parts, "parts", 1, "Number to partition warehouses")
 	cmd.PersistentFlags().IntVar(&tpccConfig.Warehouses, "warehouses", 10, "Number of warehouses")
 	cmd.PersistentFlags().BoolVar(&tpccConfig.CheckAll, "check-all", false, "Run all consistency checks")
-	cmd.PersistentFlags().StringVar(&tpccConfig.OutputDir, "csv.output", "", "Output directory for generating csv file when preparing")
-	cmd.PersistentFlags().StringArrayVar(&tpccConfig.Tables, "csv.tables", []string{}, "Specified tables to " +
-		"generate in csv file(repeated), valid only if csv.output is set. If not set, generate all tables by default.")
+	cmd.PersistentFlags().StringVar(&tpccConfig.OutputDir, "csv.output", "", "Output directory for generating csv file when preparing data")
+	cmd.PersistentFlags().StringArrayVar(&tpccConfig.Tables, "csv.table", []string{}, "Specified tables for " +
+		"generating csv file(repeated), valid only if csv.output is set. If this flag is not set, generate all tables by default.")
 
 	var cmdPrepare = &cobra.Command{
 		Use:   "prepare",

--- a/cmd/go-tpc/tpcc.go
+++ b/cmd/go-tpc/tpcc.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/pingcap/go-tpc/tpcc"
 	"github.com/spf13/cobra"
-	"google.golang.org/appengine/log"
 )
 
 var tpccConfig tpcc.Config
@@ -19,7 +19,7 @@ func executeTpcc(action string, args []string) {
 	tpccConfig.Isolation = isolationLevel
 	w, err := tpcc.NewWorkloader(globalDB, &tpccConfig)
 	if err != nil {
-		log.Errorf(context.Background(), "failed to init work loader %v", err)
+		fmt.Printf("failed to init work loader %v\n", err)
 		os.Exit(1)
 	}
 

--- a/cmd/go-tpc/tpcc.go
+++ b/cmd/go-tpc/tpcc.go
@@ -22,6 +22,7 @@ func executeTpcc(action string, args []string) {
 		}
 	}
 
+	tpccConfig.DBName = dbName
 	tpccConfig.Threads = threads
 	tpccConfig.Isolation = isolationLevel
 	w, err := tpcc.NewWorkloader(globalDB, &tpccConfig)

--- a/cmd/go-tpc/tpcc.go
+++ b/cmd/go-tpc/tpcc.go
@@ -12,8 +12,10 @@ import (
 var tpccConfig tpcc.Config
 
 func executeTpcc(action string, args []string) {
-	openDB()
-	defer closeDB()
+	if tpccConfig.OutputDir == "" {
+		openDB()
+		defer closeDB()
+	}
 
 	tpccConfig.Threads = threads
 	tpccConfig.Isolation = isolationLevel

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/go-sql-driver/mysql v1.4.1
+	github.com/google/uuid v1.1.1
 	github.com/spf13/cobra v0.0.5
-	google.golang.org/appengine v1.6.2 // indirect
+	google.golang.org/appengine v1.6.2
 )

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/google/uuid v1.1.1
 	github.com/spf13/cobra v0.0.5
-	google.golang.org/appengine v1.6.2
+	google.golang.org/appengine v1.6.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
@@ -35,6 +37,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190603091049-60506f45cf65 h1:+rhAzEzT3f4JtomfC371qB+0Ola2caSKcY69NUBZrRQ=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/load/batch_loader.go
+++ b/pkg/load/batch_loader.go
@@ -37,7 +37,7 @@ func NewSQLBatchLoader(conn *sql.Conn, hint string) *SQLBatchLoader {
 	}
 }
 
-// InsertValue inserts an value, the loader may flush all pending values.
+// InsertValue inserts a value, the loader may flush all pending values.
 func (b *SQLBatchLoader) InsertValue(ctx context.Context, query string) error {
 	sep := ", "
 	if b.count == 0 {
@@ -85,7 +85,7 @@ func NewCSVBatchLoader(flock *util.Flock) *CSVBatchLoader {
 	}
 }
 
-// InsertValue inserts an Insert value, the loader may flush all pending values.
+// InsertValue inserts a value, the loader may flush all pending values.
 func (b *CSVBatchLoader) InsertValue(ctx context.Context, query string) error {
 	fields := strings.Split(query, ",  ")
 	for i, field := range fields {

--- a/pkg/load/batch_loader.go
+++ b/pkg/load/batch_loader.go
@@ -87,7 +87,7 @@ func NewCSVBatchLoader(flock *util.Flock) *CSVBatchLoader {
 
 // InsertValue inserts a value, the loader may flush all pending values.
 func (b *CSVBatchLoader) InsertValue(ctx context.Context, query string) error {
-	fields := strings.Split(query, ",  ")
+	fields := strings.Split(query, ", ")
 	for i, field := range fields {
 		// remove '' in string type field
 		fields[i] = strings.Trim(field, `'`)

--- a/pkg/load/batch_loader.go
+++ b/pkg/load/batch_loader.go
@@ -4,38 +4,48 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/csv"
+	"strings"
+	"sync"
+
+	"github.com/pingcap/go-tpc/pkg/util"
 )
 
 const (
 	maxBatchCount = 1024
 )
 
-// BulkLoader helps us insert in batch
-type BatchLoader struct {
+type BatchLoader interface {
+	InsertValue(ctx context.Context, query string) error
+	Flush(ctx context.Context) error
+}
+
+// SQLBatchLoader helps us insert in batch
+type SQLBatchLoader struct {
 	insertHint string
 	conn       *sql.Conn
 	buf        bytes.Buffer
 	count      int
 }
 
-// NewBatchLoader creates a batch loader
-func NewBatchLoader(conn *sql.Conn, hint string) *BatchLoader {
-	return &BatchLoader{
+// NewSQLBatchLoader creates a batch loader for sql database
+func NewSQLBatchLoader(conn *sql.Conn, hint string) *SQLBatchLoader {
+	return &SQLBatchLoader{
 		count:      0,
 		insertHint: hint,
 		conn:       conn,
 	}
 }
 
-// Insert inserts an Insert value, the loader may flush all pending values.
-func (b *BatchLoader) InsertValue(ctx context.Context, query string) error {
+// InsertValue inserts an value, the loader may flush all pending values.
+func (b *SQLBatchLoader) InsertValue(ctx context.Context, query string) error {
 	sep := ", "
 	if b.count == 0 {
 		b.buf.WriteString(b.insertHint)
 		sep = " "
 	}
 	b.buf.WriteString(sep)
-	b.buf.WriteString(query)
+	b.buf.WriteString("(" + query + ")")
 
 	b.count++
 
@@ -47,7 +57,7 @@ func (b *BatchLoader) InsertValue(ctx context.Context, query string) error {
 }
 
 // Flush inserts all pending values
-func (b *BatchLoader) Flush(ctx context.Context) error {
+func (b *SQLBatchLoader) Flush(ctx context.Context) error {
 	if b.buf.Len() == 0 {
 		return nil
 	}
@@ -55,6 +65,52 @@ func (b *BatchLoader) Flush(ctx context.Context) error {
 	_, err := b.conn.ExecContext(ctx, b.buf.String())
 	b.count = 0
 	b.buf.Reset()
+
+	return err
+}
+
+// BulkLoader helps us insert in batch
+type CSVBatchLoader struct {
+	buf        [][]string
+	writer     *csv.Writer
+	mutex      *sync.Mutex
+}
+
+// NewCSVBatchLoader creates a batch loader for csv format
+func NewCSVBatchLoader(flock *util.Flock) *CSVBatchLoader {
+	return &CSVBatchLoader{
+		buf:    make([][]string, 0, maxBatchCount),
+		writer: csv.NewWriter(flock.File),
+		mutex:  flock.Mutex,
+	}
+}
+
+// InsertValue inserts an Insert value, the loader may flush all pending values.
+func (b *CSVBatchLoader) InsertValue(ctx context.Context, query string) error {
+	fields := strings.Split(query, ",  ")
+	for i, field := range fields {
+		fields[i] = strings.Trim(field, `'`)
+	}
+	b.buf = append(b.buf, fields)
+
+	if len(b.buf) >= maxBatchCount {
+		return b.Flush(ctx)
+	}
+
+	return nil
+}
+
+// Flush inserts all pending values
+func (b *CSVBatchLoader) Flush(ctx context.Context) error {
+	if len(b.buf) == 0 {
+		return nil
+	}
+
+	b.mutex.Lock()
+	err := b.writer.WriteAll(b.buf)
+	b.buf = b.buf[:0]
+	b.writer.Flush()
+	b.mutex.Unlock()
 
 	return err
 }

--- a/pkg/load/batch_loader.go
+++ b/pkg/load/batch_loader.go
@@ -28,7 +28,7 @@ type SQLBatchLoader struct {
 	count      int
 }
 
-// NewSQLBatchLoader creates a batch loader for sql database
+// NewSQLBatchLoader creates a batch loader for database connection
 func NewSQLBatchLoader(conn *sql.Conn, hint string) *SQLBatchLoader {
 	return &SQLBatchLoader{
 		count:      0,
@@ -69,7 +69,7 @@ func (b *SQLBatchLoader) Flush(ctx context.Context) error {
 	return err
 }
 
-// BulkLoader helps us insert in batch
+// CSVBatchLoader helps us insert in batch
 type CSVBatchLoader struct {
 	buf        [][]string
 	writer     *csv.Writer

--- a/pkg/load/batch_loader.go
+++ b/pkg/load/batch_loader.go
@@ -89,6 +89,7 @@ func NewCSVBatchLoader(flock *util.Flock) *CSVBatchLoader {
 func (b *CSVBatchLoader) InsertValue(ctx context.Context, query string) error {
 	fields := strings.Split(query, ",  ")
 	for i, field := range fields {
+		// remove '' in string type field
 		fields[i] = strings.Trim(field, `'`)
 	}
 	b.buf = append(b.buf, fields)

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -6,7 +6,7 @@ import (
 )
 
 func CreateFile(path string) (*os.File, error) {
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -1,19 +1,15 @@
 package util
 
 import (
+	"fmt"
 	"os"
-	"sync"
 )
 
-func CreateFile(path string) (*os.File, error) {
+func CreateFile(path string) *os.File {
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
-		return nil, err
+		fmt.Printf("failed to create file %s, error %v", path, err)
+		os.Exit(1)
 	}
-	return f, nil
-}
-
-type Flock struct {
-	*os.File
-	*sync.Mutex
+	return f
 }

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -6,7 +6,7 @@ import (
 )
 
 func CreateFile(path string) (*os.File, error) {
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0666)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -1,0 +1,19 @@
+package util
+
+import (
+	"os"
+	"sync"
+)
+
+func CreateFile(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+type Flock struct {
+	*os.File
+	*sync.Mutex
+}

--- a/pkg/workload/base.go
+++ b/pkg/workload/base.go
@@ -20,9 +20,13 @@ type TpcState struct {
 
 // NewTpcState creates a base TpcState
 func NewTpcState(ctx context.Context, db *sql.DB) *TpcState {
-	conn, err := db.Conn(ctx)
-	if err != nil {
-		panic(err.Error())
+	var conn *sql.Conn
+	var err error
+	if db != nil {
+		conn, err = db.Conn(ctx)
+		if err != nil {
+			panic(err.Error())
+		}
 	}
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -14,4 +14,5 @@ type Workloader interface {
 	Run(ctx context.Context, threadID int) error
 	Cleanup(ctx context.Context, threadID int) error
 	Check(ctx context.Context, threadID int) error
+	DataGen() bool
 }

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -15,4 +15,5 @@ type Workloader interface {
 	Cleanup(ctx context.Context, threadID int) error
 	Check(ctx context.Context, threadID int) error
 	DataGen() bool
+	DBName() string
 }

--- a/tpcc/ddl.go
+++ b/tpcc/ddl.go
@@ -5,6 +5,18 @@ import (
 	"fmt"
 )
 
+const (
+	tableItem      = "item"
+	tableCustomer  = "customer"
+	tableDistrict  = "district"
+	tableOrders    = "orders"
+	tableNewOrder  = "new_order"
+	tableOrderLine = "order_line"
+	tableHistory   = "history"
+	tableWareHouse = "warehouse"
+	tableStock     = "stock"
+)
+
 func (w *Workloader) createTableDDL(ctx context.Context, query string, tableName string, action string) error {
 	s := w.getState(ctx)
 	fmt.Printf("%s %s\n", action, tableName)
@@ -229,10 +241,6 @@ CREATE TABLE IF NOT EXISTS item (
 
 func (w *Workloader) dropTable(ctx context.Context) error {
 	s := w.getState(ctx)
-	tables := []string{
-		"warehouse", "history", "new_order", "order_line", "orders", "customer", "district", "stock", "item",
-	}
-
 	for _, tbl := range tables {
 		fmt.Printf("DROP TABLE IF EXISTS %s\n", tbl)
 		if _, err := s.Conn.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tbl)); err != nil {

--- a/tpcc/ddl.go
+++ b/tpcc/ddl.go
@@ -103,7 +103,6 @@ CREATE TABLE IF NOT EXISTS customer (
 
 	query = `
 CREATE TABLE IF NOT EXISTS history (
-	row_id BINARY(16) NOT NULL,
 	h_c_id INT NOT NULL,
 	h_c_d_id INT NOT NULL,
 	h_c_w_id INT NOT NULL,
@@ -112,7 +111,7 @@ CREATE TABLE IF NOT EXISTS history (
 	h_date DATETIME,
 	h_amount DECIMAL(6, 2),
 	h_data VARCHAR(24),
-	PRIMARY KEY(h_w_id, row_id),
+	INDEX idx_h_w_id (h_w_id),
 	INDEX idx_h_c_w_id (h_c_w_id)
 )`
 

--- a/tpcc/load.go
+++ b/tpcc/load.go
@@ -2,13 +2,10 @@ package tpcc
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"math/rand"
 	"strconv"
-	"strings"
 
-	"github.com/google/uuid"
 	"github.com/pingcap/go-tpc/pkg/load"
 )
 
@@ -43,7 +40,7 @@ func (w *Workloader) loadItem(ctx context.Context) error {
 		iName := randChars(s.R, s.Buf, 14, 24)
 		iData := randOriginalString(s.R, s.Buf)
 
-		v := fmt.Sprintf(`%d,  %d,  '%s',  %f,  '%s'`, i+1, iImID, iName, iPrice, iData)
+		v := fmt.Sprintf(`%d, %d, '%s', %f, '%s'`, i+1, iImID, iName, iPrice, iData)
 
 		if err := l.InsertValue(ctx, v); err != nil {
 			return err
@@ -74,7 +71,7 @@ func (w *Workloader) loadWarehouse(ctx context.Context, warehouse int) error {
 	wTax := randTax(s.R)
 	wYtd := 300000.00
 
-	v := fmt.Sprintf(`%d,  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  %f,  %f`,
+	v := fmt.Sprintf(`%d, '%s', '%s', '%s', '%s', '%s', '%s', %f, %f`,
 		warehouse, wName, wStree1, wStree2, wCity, wState, wZip, wTax, wYtd)
 	if err := l.InsertValue(ctx, v); err != nil {
 		return err
@@ -120,7 +117,7 @@ s_dist_07, s_dist_08, s_dist_09, s_dist_10, s_ytd, s_order_cnt, s_remote_cnt, s_
 		sRemoteCnt := 0
 		sData := randOriginalString(s.R, s.Buf)
 
-		v := fmt.Sprintf(`%d,  %d,  %d,  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  %d,  %d,  %d,  '%s'`,
+		v := fmt.Sprintf(`%d, %d, %d, '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', %d, %d, %d, '%s'`,
 			sIID, sWID, sQuantity, sDist01, sDist02, sDist03, sDist04, sDist05, sDist06, sDist07, sDist08, sDist09, sDist10, sYtd, sOrderCnt, sRemoteCnt, sData)
 		if err := l.InsertValue(ctx, v); err != nil {
 			return err
@@ -159,7 +156,7 @@ d_city, d_state, d_zip, d_tax, d_ytd, d_next_o_id) VALUES `
 		dYtd := 30000.00
 		dNextOID := 3001
 
-		v := fmt.Sprintf(`%d,  %d,  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  %f,  %f,  %d`, dID, dWID,
+		v := fmt.Sprintf(`%d, %d, '%s', '%s', '%s', '%s', '%s', '%s', %f, %f, %d`, dID, dWID,
 			dName, dStreet1, dStreet2, dCity, dState, dZip, dTax, dYtd, dNextOID)
 
 		if err := l.InsertValue(ctx, v); err != nil {
@@ -218,7 +215,7 @@ c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data) VAL
 		cDeliveryCnt := 0
 		cData := randChars(s.R, s.Buf, 300, 500)
 
-		v := fmt.Sprintf(`%d,  %d,  %d,  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  %f,  %f,  %f,  %f,  %d,  %d,  '%s'`,
+		v := fmt.Sprintf(`%d, %d, %d, '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', %f, %f, %f, %f, %d, %d, '%s'`,
 			cID, cDID, cWID, cLast, cMiddle, cFirst, cStreet1, cStreet2, cCity, cState,
 			cZip, cPhone, cSince, cCredit, cCreditLim, cDisCount, cBalance,
 			cYtdPayment, cPaymentCnt, cDeliveryCnt, cData)
@@ -235,7 +232,7 @@ func (w *Workloader) loadHistory(ctx context.Context, warehouse int, district in
 
 	s := w.getState(ctx)
 
-	hint := `INSERT INTO history (row_id, h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES `
+	hint := `INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES `
 
 	var l load.BatchLoader
 	if w.cfg.OutputDir != "" {
@@ -257,20 +254,8 @@ func (w *Workloader) loadHistory(ctx context.Context, warehouse int, district in
 		hAmount := 10.00
 		hData := randChars(s.R, s.Buf, 12, 24)
 
-		id := `unhex(replace(uuid(), '-', ''))`
-		if w.cfg.OutputDir != "" {
-			uid, err := uuid.NewUUID()
-			if err != nil {
-				return err
-			}
-			bytes, err := hex.DecodeString(strings.Replace(uid.String(), "-", "", -1))
-			if err != nil {
-				return err
-			}
-			id = string(bytes)
-		}
-		v := fmt.Sprintf(`%s,  %d,  %d,  %d,  %d,  %d,  '%s',  %f,  '%s'`,
-			id, hCID, hCDID, hCWID, hDID, hWID, hDate, hAmount, hData)
+		v := fmt.Sprintf(`%d, %d, %d, %d, %d, '%s', %f, '%s'`,
+			hCID, hCDID, hCWID, hDID, hWID, hDate, hAmount, hData)
 		if err := l.InsertValue(ctx, v); err != nil {
 			return err
 		}
@@ -314,7 +299,7 @@ o_carrier_id, o_ol_cnt, o_all_local) VALUES `
 		olCnts[i] = oOLCnt
 		oAllLocal := 1
 
-		v := fmt.Sprintf(`%d,  %d,  %d,  %d,  '%s',  '%s',  %d,  %d`, oID, oDID, oWID, oCID, oEntryD, oCarrierID, oOLCnt, oAllLocal)
+		v := fmt.Sprintf(`%d, %d, %d, %d, '%s', '%s', %d, %d`, oID, oDID, oWID, oCID, oEntryD, oCarrierID, oOLCnt, oAllLocal)
 		if err := l.InsertValue(ctx, v); err != nil {
 			return nil, err
 		}
@@ -344,7 +329,7 @@ func (w *Workloader) loadNewOrder(ctx context.Context, warehouse int, district i
 		noDID := district
 		noWID := warehouse
 
-		v := fmt.Sprintf(`%d,  %d,  %d`, noOID, noDID, noWID)
+		v := fmt.Sprintf(`%d, %d, %d`, noOID, noDID, noWID)
 		if err := l.InsertValue(ctx, v); err != nil {
 			return err
 		}
@@ -390,7 +375,7 @@ ol_i_id, ol_supply_w_id, ol_delivery_d, ol_quantity, ol_amount, ol_dist_info) VA
 				olAmount = float64(randInt(s.R, 1, 999999)) / 100.0
 			}
 			olDistInfo := randChars(s.R, s.Buf, 24, 24)
-			v := fmt.Sprintf(`%d,  %d,  %d,  %d,  %d,  %d,  %s,  %d,  %f,  '%s'`,
+			v := fmt.Sprintf(`%d, %d, %d, %d, %d, %d, %s, %d, %f, '%s'`,
 				olOID, olDID, olWID, olNumber, olIID, olSupplyWID,
 				olDeliveryD, olQuantity, olAmount, olDistInfo)
 			if err := l.InsertValue(ctx, v); err != nil {

--- a/tpcc/load.go
+++ b/tpcc/load.go
@@ -21,13 +21,16 @@ const (
 )
 
 func (w *Workloader) loadItem(ctx context.Context) error {
+	if !w.tables[tableItem] {
+		return nil
+	}
 	fmt.Printf("load to item\n")
 	s := w.getState(ctx)
 	hint := "INSERT INTO item (i_id, i_im_id, i_name, i_price, i_data) VALUES "
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files["item"])
+		l = load.NewCSVBatchLoader(w.files[tableItem])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -51,13 +54,16 @@ func (w *Workloader) loadItem(ctx context.Context) error {
 }
 
 func (w *Workloader) loadWarehouse(ctx context.Context, warehouse int) error {
+	if !w.tables[tableWareHouse] {
+		return nil
+	}
 	fmt.Printf("load to warehouse in warehouse %d\n", warehouse)
 	s := w.getState(ctx)
 	hint := "INSERT INTO warehouse (w_id, w_name, w_street_1, w_street_2, w_city, w_state, w_zip, w_tax, w_ytd) VALUES "
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files["warehouse"])
+		l = load.NewCSVBatchLoader(w.files[tableWareHouse])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -81,6 +87,9 @@ func (w *Workloader) loadWarehouse(ctx context.Context, warehouse int) error {
 }
 
 func (w *Workloader) loadStock(ctx context.Context, warehouse int) error {
+	if !w.tables[tableStock] {
+		return nil
+	}
 	fmt.Printf("load to stock in warehouse %d\n", warehouse)
 
 	s := w.getState(ctx)
@@ -91,7 +100,7 @@ s_dist_07, s_dist_08, s_dist_09, s_dist_10, s_ytd, s_order_cnt, s_remote_cnt, s_
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files["stock"])
+		l = load.NewCSVBatchLoader(w.files[tableStock])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -127,6 +136,9 @@ s_dist_07, s_dist_08, s_dist_09, s_dist_10, s_ytd, s_order_cnt, s_remote_cnt, s_
 }
 
 func (w *Workloader) loadDistrict(ctx context.Context, warehouse int) error {
+	if !w.tables[tableDistrict] {
+		return nil
+	}
 	fmt.Printf("load to district in warehouse %d\n", warehouse)
 
 	s := w.getState(ctx)
@@ -136,7 +148,7 @@ d_city, d_state, d_zip, d_tax, d_ytd, d_next_o_id) VALUES `
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files["district"])
+		l = load.NewCSVBatchLoader(w.files[tableDistrict])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -167,6 +179,9 @@ d_city, d_state, d_zip, d_tax, d_ytd, d_next_o_id) VALUES `
 }
 
 func (w *Workloader) loadCustomer(ctx context.Context, warehouse int, district int) error {
+	if !w.tables[tableCustomer] {
+		return nil
+	}
 	fmt.Printf("load to customer in warehouse %d district %d\n", warehouse, district)
 
 	s := w.getState(ctx)
@@ -177,7 +192,7 @@ c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data) VAL
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files["customer"])
+		l = load.NewCSVBatchLoader(w.files[tableCustomer])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -228,6 +243,9 @@ c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data) VAL
 }
 
 func (w *Workloader) loadHistory(ctx context.Context, warehouse int, district int) error {
+	if !w.tables[tableHistory] {
+		return nil
+	}
 	fmt.Printf("load to history in warehouse %d district %d\n", warehouse, district)
 
 	s := w.getState(ctx)
@@ -236,7 +254,7 @@ func (w *Workloader) loadHistory(ctx context.Context, warehouse int, district in
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files["history"])
+		l = load.NewCSVBatchLoader(w.files[tableHistory])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -264,6 +282,9 @@ func (w *Workloader) loadHistory(ctx context.Context, warehouse int, district in
 }
 
 func (w *Workloader) loadOrder(ctx context.Context, warehouse int, district int) ([]int, error) {
+	if !w.tables[tableOrders] {
+		return nil, nil
+	}
 	fmt.Printf("load to orders in warehouse %d district %d\n", warehouse, district)
 
 	s := w.getState(ctx)
@@ -273,7 +294,7 @@ o_carrier_id, o_ol_cnt, o_all_local) VALUES `
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files["orders"])
+		l = load.NewCSVBatchLoader(w.files[tableOrders])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -309,6 +330,9 @@ o_carrier_id, o_ol_cnt, o_all_local) VALUES `
 }
 
 func (w *Workloader) loadNewOrder(ctx context.Context, warehouse int, district int) error {
+	if !w.tables[tableNewOrder] {
+		return nil
+	}
 	fmt.Printf("load to new_order in warehouse %d district %d\n", warehouse, district)
 
 	s := w.getState(ctx)
@@ -317,7 +341,7 @@ func (w *Workloader) loadNewOrder(ctx context.Context, warehouse int, district i
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files["new_order"])
+		l = load.NewCSVBatchLoader(w.files[tableNewOrder])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -339,6 +363,9 @@ func (w *Workloader) loadNewOrder(ctx context.Context, warehouse int, district i
 }
 
 func (w *Workloader) loadOrderLine(ctx context.Context, warehouse int, district int, olCnts []int) error {
+	if !w.tables[tableOrderLine] {
+		return nil
+	}
 	fmt.Printf("load to order_line in warehouse %d district %d\n", warehouse, district)
 
 	s := w.getState(ctx)
@@ -348,7 +375,7 @@ ol_i_id, ol_supply_w_id, ol_delivery_d, ol_quantity, ol_amount, ol_dist_info) VA
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files["order_line"])
+		l = load.NewCSVBatchLoader(w.files[tableOrderLine])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}

--- a/tpcc/load.go
+++ b/tpcc/load.go
@@ -26,7 +26,7 @@ func (w *Workloader) loadItem(ctx context.Context) error {
 	hint := "INSERT INTO item (i_id, i_im_id, i_name, i_price, i_data) VALUES "
 
 	var l load.BatchLoader
-	if w.cfg.OutputDir != "" {
+	if w.DataGen() {
 		l = load.NewCSVBatchLoader(w.files["item"])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
@@ -56,7 +56,7 @@ func (w *Workloader) loadWarehouse(ctx context.Context, warehouse int) error {
 	hint := "INSERT INTO warehouse (w_id, w_name, w_street_1, w_street_2, w_city, w_state, w_zip, w_tax, w_ytd) VALUES "
 
 	var l load.BatchLoader
-	if w.cfg.OutputDir != "" {
+	if w.DataGen() {
 		l = load.NewCSVBatchLoader(w.files["warehouse"])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
@@ -90,7 +90,7 @@ s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06,
 s_dist_07, s_dist_08, s_dist_09, s_dist_10, s_ytd, s_order_cnt, s_remote_cnt, s_data) VALUES `
 
 	var l load.BatchLoader
-	if w.cfg.OutputDir != "" {
+	if w.DataGen() {
 		l = load.NewCSVBatchLoader(w.files["stock"])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
@@ -135,7 +135,7 @@ func (w *Workloader) loadDistrict(ctx context.Context, warehouse int) error {
 d_city, d_state, d_zip, d_tax, d_ytd, d_next_o_id) VALUES `
 
 	var l load.BatchLoader
-	if w.cfg.OutputDir != "" {
+	if w.DataGen() {
 		l = load.NewCSVBatchLoader(w.files["district"])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
@@ -176,7 +176,7 @@ c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_since, c_credit, c_cr
 c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data) VALUES `
 
 	var l load.BatchLoader
-	if w.cfg.OutputDir != "" {
+	if w.DataGen() {
 		l = load.NewCSVBatchLoader(w.files["customer"])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
@@ -235,7 +235,7 @@ func (w *Workloader) loadHistory(ctx context.Context, warehouse int, district in
 	hint := `INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES `
 
 	var l load.BatchLoader
-	if w.cfg.OutputDir != "" {
+	if w.DataGen() {
 		l = load.NewCSVBatchLoader(w.files["history"])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
@@ -272,7 +272,7 @@ func (w *Workloader) loadOrder(ctx context.Context, warehouse int, district int)
 o_carrier_id, o_ol_cnt, o_all_local) VALUES `
 
 	var l load.BatchLoader
-	if w.cfg.OutputDir != "" {
+	if w.DataGen() {
 		l = load.NewCSVBatchLoader(w.files["orders"])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
@@ -299,7 +299,7 @@ o_carrier_id, o_ol_cnt, o_all_local) VALUES `
 		olCnts[i] = oOLCnt
 		oAllLocal := 1
 
-		v := fmt.Sprintf(`%d, %d, %d, %d, '%s', '%s', %d, %d`, oID, oDID, oWID, oCID, oEntryD, oCarrierID, oOLCnt, oAllLocal)
+		v := fmt.Sprintf(`%d, %d, %d, %d, '%s', %s, %d, %d`, oID, oDID, oWID, oCID, oEntryD, oCarrierID, oOLCnt, oAllLocal)
 		if err := l.InsertValue(ctx, v); err != nil {
 			return nil, err
 		}
@@ -316,7 +316,7 @@ func (w *Workloader) loadNewOrder(ctx context.Context, warehouse int, district i
 	hint := `INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES `
 
 	var l load.BatchLoader
-	if w.cfg.OutputDir != "" {
+	if w.DataGen() {
 		l = load.NewCSVBatchLoader(w.files["new_order"])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
@@ -347,7 +347,7 @@ func (w *Workloader) loadOrderLine(ctx context.Context, warehouse int, district 
 ol_i_id, ol_supply_w_id, ol_delivery_d, ol_quantity, ol_amount, ol_dist_info) VALUES `
 
 	var l load.BatchLoader
-	if w.cfg.OutputDir != "" {
+	if w.DataGen() {
 		l = load.NewCSVBatchLoader(w.files["order_line"])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)

--- a/tpcc/load.go
+++ b/tpcc/load.go
@@ -283,7 +283,7 @@ func (w *Workloader) loadOrder(ctx context.Context, warehouse int, district int)
 
 	s := w.getState(ctx)
 
-	hint := `INSERT INTO orders (o_id, o_c_id, o_d_id, o_w_id, o_entry_d, 
+	hint := `INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, 
 o_carrier_id, o_ol_cnt, o_all_local) VALUES `
 
 	var l load.BatchLoader
@@ -314,7 +314,7 @@ o_carrier_id, o_ol_cnt, o_all_local) VALUES `
 		olCnts[i] = oOLCnt
 		oAllLocal := 1
 
-		v := fmt.Sprintf(`%d,  %d,  %d,  %d,  '%s',  %s,  %d,  %d`, oID, oCID, oDID, oWID, oEntryD, oCarrierID, oOLCnt, oAllLocal)
+		v := fmt.Sprintf(`%d,  %d,  %d,  %d,  '%s',  '%s',  %d,  %d`, oID, oDID, oWID, oCID, oEntryD, oCarrierID, oOLCnt, oAllLocal)
 		if err := l.InsertValue(ctx, v); err != nil {
 			return nil, err
 		}

--- a/tpcc/load.go
+++ b/tpcc/load.go
@@ -186,7 +186,7 @@ func (w *Workloader) loadCustomer(ctx context.Context, warehouse int, district i
 
 	s := w.getState(ctx)
 
-	hint := `INSERT INTO customer (c_id, c_d_id, c_w_id, c_last, c_middle, c_first, 
+	hint := `INSERT INTO customer (c_id, c_d_id, c_w_id, c_first, c_middle, c_last, 
 c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim,
 c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data) VALUES `
 
@@ -231,7 +231,7 @@ c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data) VAL
 		cData := randChars(s.R, s.Buf, 300, 500)
 
 		v := fmt.Sprintf(`%d, %d, %d, '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', %f, %f, %f, %f, %d, %d, '%s'`,
-			cID, cDID, cWID, cLast, cMiddle, cFirst, cStreet1, cStreet2, cCity, cState,
+			cID, cDID, cWID, cFirst, cMiddle, cLast, cStreet1, cStreet2, cCity, cState,
 			cZip, cPhone, cSince, cCredit, cCreditLim, cDisCount, cBalance,
 			cYtdPayment, cPaymentCnt, cDeliveryCnt, cData)
 		if err := l.InsertValue(ctx, v); err != nil {

--- a/tpcc/load.go
+++ b/tpcc/load.go
@@ -30,7 +30,7 @@ func (w *Workloader) loadItem(ctx context.Context) error {
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files[tableItem])
+		l = load.NewCSVBatchLoader(s.files[tableItem])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -63,7 +63,7 @@ func (w *Workloader) loadWarehouse(ctx context.Context, warehouse int) error {
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files[tableWareHouse])
+		l = load.NewCSVBatchLoader(s.files[tableWareHouse])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -100,7 +100,7 @@ s_dist_07, s_dist_08, s_dist_09, s_dist_10, s_ytd, s_order_cnt, s_remote_cnt, s_
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files[tableStock])
+		l = load.NewCSVBatchLoader(s.files[tableStock])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -148,7 +148,7 @@ d_city, d_state, d_zip, d_tax, d_ytd, d_next_o_id) VALUES `
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files[tableDistrict])
+		l = load.NewCSVBatchLoader(s.files[tableDistrict])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -192,7 +192,7 @@ c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data) VAL
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files[tableCustomer])
+		l = load.NewCSVBatchLoader(s.files[tableCustomer])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -254,7 +254,7 @@ func (w *Workloader) loadHistory(ctx context.Context, warehouse int, district in
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files[tableHistory])
+		l = load.NewCSVBatchLoader(s.files[tableHistory])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -294,7 +294,7 @@ o_carrier_id, o_ol_cnt, o_all_local) VALUES `
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files[tableOrders])
+		l = load.NewCSVBatchLoader(s.files[tableOrders])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -341,7 +341,7 @@ func (w *Workloader) loadNewOrder(ctx context.Context, warehouse int, district i
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files[tableNewOrder])
+		l = load.NewCSVBatchLoader(s.files[tableNewOrder])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}
@@ -375,7 +375,7 @@ ol_i_id, ol_supply_w_id, ol_delivery_d, ol_quantity, ol_amount, ol_dist_info) VA
 
 	var l load.BatchLoader
 	if w.DataGen() {
-		l = load.NewCSVBatchLoader(w.files[tableOrderLine])
+		l = load.NewCSVBatchLoader(s.files[tableOrderLine])
 	} else {
 		l = load.NewSQLBatchLoader(s.Conn, hint)
 	}

--- a/tpcc/workload.go
+++ b/tpcc/workload.go
@@ -325,9 +325,9 @@ func (w *Workloader) Cleanup(ctx context.Context, threadID int) error {
 		if err := w.dropTable(ctx); err != nil {
 			return err
 		}
-		//for _, f := range w.files {
-		//	f.Close()
-		//}
+		for _, f := range w.files {
+			f.Close()
+		}
 	}
 	return nil
 }

--- a/tpcc/workload.go
+++ b/tpcc/workload.go
@@ -58,7 +58,6 @@ type Workloader struct {
 	createTableWg sync.WaitGroup
 	initLoadTime  string
 
-	mutex sync.Mutex
 	files map[string]*util.Flock
 
 	txns []txn
@@ -92,11 +91,9 @@ func NewWorkloader(db *sql.DB, cfg *Config) (workload.Workloader, error) {
 				return nil, err
 			}
 		}
-		w.mutex = sync.Mutex{}
 		w.files = make(map[string]*util.Flock)
 
 		var fl *util.Flock
-		w.mutex.Lock()
 		tables := []string{"item", "customer", "district", "orders", "new_order", "order_line",
 			"history", "warehouse", "stock"}
 		for _, table := range tables {

--- a/tpcc/workload.go
+++ b/tpcc/workload.go
@@ -79,6 +79,7 @@ func NewWorkloader(db *sql.DB, cfg *Config) (workload.Workloader, error) {
 		db:           db,
 		cfg:          cfg,
 		initLoadTime: time.Now().Format(timeFormat),
+		tables:       make(map[string]bool),
 	}
 
 	w.txns = []txn{
@@ -87,6 +88,14 @@ func NewWorkloader(db *sql.DB, cfg *Config) (workload.Workloader, error) {
 		{name: "order_status", action: w.runOrderStatus, weight: 4},
 		{name: "delivery", action: w.runDelivery, weight: 4},
 		{name: "stock_level", action: w.runStockLevel, weight: 4},
+	}
+
+	var val bool
+	if len(cfg.Tables) == 0 {
+		val = true
+	}
+	for _, table := range tables {
+		w.tables[table] = val
 	}
 
 	if w.cfg.OutputDir != "" {
@@ -100,15 +109,6 @@ func NewWorkloader(db *sql.DB, cfg *Config) (workload.Workloader, error) {
 			}
 		}
 		w.files = make(map[string]*util.Flock)
-
-		w.tables = make(map[string]bool)
-		var val bool
-		if len(cfg.Tables) == 0 {
-			val = true
-		}
-		for _, table := range tables {
-			w.tables[table] = val
-		}
 
 		for _, t := range cfg.Tables {
 			if _, ok := w.tables[t]; !ok {

--- a/tpch/loader.go
+++ b/tpch/loader.go
@@ -9,16 +9,16 @@ import (
 )
 
 type sqlLoader struct {
-	*load.BatchLoader
+	*load.SQLBatchLoader
 	context.Context
 }
 
 func (s *sqlLoader) InsertValue(value string) error {
-	return s.BatchLoader.InsertValue(s.Context, value)
+	return s.SQLBatchLoader.InsertValue(s.Context, value)
 }
 
 func (s *sqlLoader) Flush() error {
-	return s.BatchLoader.Flush(s.Context)
+	return s.SQLBatchLoader.Flush(s.Context)
 }
 
 type orderLoader struct {
@@ -174,42 +174,42 @@ func (r *regionLoader) Load(item interface{}) error {
 }
 
 func newOrderLoader(ctx context.Context, conn *sql.Conn) *orderLoader {
-	return &orderLoader{sqlLoader{load.NewBatchLoader(conn,
+	return &orderLoader{sqlLoader{load.NewSQLBatchLoader(conn,
 		`INSERT INTO orders (O_ORDERKEY, O_CUSTKEY, O_ORDERSTATUS, O_TOTALPRICE, O_ORDERDATE, O_ORDERPRIORITY, O_CLERK, O_SHIPPRIORITY, O_COMMENT) VALUES `),
 		ctx}}
 }
 func newLineItemLoader(ctx context.Context, conn *sql.Conn) *lineItemloader {
-	return &lineItemloader{sqlLoader{load.NewBatchLoader(conn,
+	return &lineItemloader{sqlLoader{load.NewSQLBatchLoader(conn,
 		`INSERT INTO lineitem (L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER, L_QUANTITY, L_EXTENDEDPRICE, L_DISCOUNT, L_TAX, L_RETURNFLAG, L_LINESTATUS, L_SHIPDATE, L_COMMITDATE, L_RECEIPTDATE, L_SHIPINSTRUCT, L_SHIPMODE, L_COMMENT) VALUES `),
 		ctx}}
 }
 func newCustLoader(ctx context.Context, conn *sql.Conn) *custLoader {
-	return &custLoader{sqlLoader{load.NewBatchLoader(conn,
+	return &custLoader{sqlLoader{load.NewSQLBatchLoader(conn,
 		`INSERT INTO customer (C_CUSTKEY, C_NAME, C_ADDRESS, C_NATIONKEY, C_PHONE, C_ACCTBAL, C_MKTSEGMENT, C_COMMENT) VALUES `),
 		ctx}}
 }
 func newPartLoader(ctx context.Context, conn *sql.Conn) *partLoader {
-	return &partLoader{sqlLoader{load.NewBatchLoader(conn,
+	return &partLoader{sqlLoader{load.NewSQLBatchLoader(conn,
 		`INSERT INTO part (P_PARTKEY, P_NAME, P_MFGR, P_BRAND, P_TYPE, P_SIZE, P_CONTAINER, P_RETAILPRICE, P_COMMENT) VALUES `),
 		ctx}}
 }
 func newPartSuppLoader(ctx context.Context, conn *sql.Conn) *partSuppLoader {
-	return &partSuppLoader{sqlLoader{load.NewBatchLoader(conn,
+	return &partSuppLoader{sqlLoader{load.NewSQLBatchLoader(conn,
 		`INSERT INTO partsupp (PS_PARTKEY, PS_SUPPKEY, PS_AVAILQTY, PS_SUPPLYCOST, PS_COMMENT) VALUES `),
 		ctx}}
 }
 func newSuppLoader(ctx context.Context, conn *sql.Conn) *suppLoader {
-	return &suppLoader{sqlLoader{load.NewBatchLoader(conn,
+	return &suppLoader{sqlLoader{load.NewSQLBatchLoader(conn,
 		`INSERT INTO supplier (S_SUPPKEY, S_NAME, S_ADDRESS, S_NATIONKEY, S_PHONE, S_ACCTBAL, S_COMMENT) VALUES `),
 		ctx}}
 }
 func newNationLoader(ctx context.Context, conn *sql.Conn) *nationLoader {
-	return &nationLoader{sqlLoader{load.NewBatchLoader(conn,
+	return &nationLoader{sqlLoader{load.NewSQLBatchLoader(conn,
 		`INSERT INTO nation (N_NATIONKEY, N_NAME, N_REGIONKEY, N_COMMENT) VALUES `),
 		ctx}}
 }
 func newRegionLoader(ctx context.Context, conn *sql.Conn) *regionLoader {
-	return &regionLoader{sqlLoader{load.NewBatchLoader(conn,
+	return &regionLoader{sqlLoader{load.NewSQLBatchLoader(conn,
 		`INSERT INTO region (R_REGIONKEY, R_NAME, R_COMMENT) VALUES `),
 		ctx}}
 }

--- a/tpch/workload.go
+++ b/tpch/workload.go
@@ -145,3 +145,8 @@ func (w Workloader) Check(ctx context.Context, threadID int) error {
 func (w Workloader) DataGen() bool {
 	return false
 }
+
+// DBName returns the name of test db.
+func (w Workloader) DBName() string {
+	return "not implemented"
+}

--- a/tpch/workload.go
+++ b/tpch/workload.go
@@ -140,3 +140,8 @@ func (w Workloader) Cleanup(ctx context.Context, threadID int) error {
 func (w Workloader) Check(ctx context.Context, threadID int) error {
 	return nil
 }
+
+// DataGen returns a bool to represent whether to generate csv data or load data to db.
+func (w Workloader) DataGen() bool {
+	return false
+}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Fix https://github.com/pingcap/go-tpc/issues/14

This PR also supports specifying tables now. If `--csv.table` is not set, by default it will generates all 9 tables data.

Example usage:

```
./go-tpc tpcc prepare --csv.output data --csv.table orders --csv.table customer --csv.table history  --warehouses 100
```

