### PR TITLE
Improve table specify flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ For example:
 # Generate csv files
 ./bin/go-tpc tpcc --warehouses 4 prepare --csv.output data
 # Specified tables when generating csv files
-./bin/go-tpc tpcc --warehouses 4 prepare --csv.output data --csv.table history --csv.table orders
-
+./bin/go-tpc tpcc --warehouses 4 prepare --csv.output data --csv.tables history,orders
 # Start pprof
 ./bin/go-tpc tpcc --warehouses 4 prepare --csv.output data --pprof :10111
 ```

--- a/cmd/go-tpc/tpcc.go
+++ b/cmd/go-tpc/tpcc.go
@@ -47,8 +47,8 @@ func registerTpcc(root *cobra.Command) {
 	cmd.PersistentFlags().IntVar(&tpccConfig.Warehouses, "warehouses", 10, "Number of warehouses")
 	cmd.PersistentFlags().BoolVar(&tpccConfig.CheckAll, "check-all", false, "Run all consistency checks")
 	cmd.PersistentFlags().StringVar(&tpccConfig.OutputDir, "csv.output", "", "Output directory for generating csv file when preparing data")
-	cmd.PersistentFlags().StringArrayVar(&tpccConfig.Tables, "csv.table", []string{}, "Specified tables for "+
-		"generating csv file(repeated), valid only if csv.output is set. If this flag is not set, generate all tables by default.")
+	cmd.PersistentFlags().StringVar(&tpccConfig.SpecifiedTables, "csv.tables", "", "Specified tables for "+
+		"generating csv file, separated by ','. Valid only if csv.output is set. If this flag is not set, generate all tables by default.")
 
 	var cmdPrepare = &cobra.Command{
 		Use:   "prepare",


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Please merge #21 first

The previous `csv.table` flag needs to be specified repeatedly, which is not that user-friendly.

This PR updates that flag, rename it to `csv.tables`, table names separated by `,`. It can be used like:

```
./bin/go-tpc tpcc --warehouses 4 prepare --csv.output data --csv.tables history,orders,customer
``` 