### PR TITLE
Update tpcc run statement against table history

### DIFF
--- a/tpcc/new_order.go
+++ b/tpcc/new_order.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 func genNewOrderSelectItemsSQL(cnt int) string {
-	buf := bytes.NewBufferString("SELECT i_price, i_name, i_data, i_id FROM ITEM WHERE i_id IN (")
+	buf := bytes.NewBufferString("SELECT i_price, i_name, i_data, i_id FROM item WHERE i_id IN (")
 	for i := 0; i < cnt; i++ {
 		if i != 0 {
 			buf.WriteByte(',')

--- a/tpcc/payment.go
+++ b/tpcc/payment.go
@@ -20,8 +20,8 @@ c_payment_cnt = c_payment_cnt + 1 WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?`
 	paymentSelectCustomerData     = `SELECT c_data FROM customer WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?`
 	paymentUpdateCustomerWithData = `UPDATE customer SET c_balance = c_balance - ?, c_ytd_payment = c_ytd_payment + ?, 
 c_payment_cnt = c_payment_cnt + 1, c_data = ? WHERE c_w_id = ? AND c_d_id = ? AND c_id = ?`
-	paymentInsertHistory = `INSERT INTO history (row_id, h_c_d_id, h_c_w_id, h_c_id, h_d_id, h_w_id, h_date, h_amount, h_data)
-VALUES (unhex(replace(uuid(), '-', '')), ?, ?, ?, ?, ?, ?, ?, ?)`
+	paymentInsertHistory = `INSERT INTO history (h_c_d_id, h_c_w_id, h_c_id, h_d_id, h_w_id, h_date, h_amount, h_data)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 )
 
 type paymentData struct {


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

In this [pr](https://github.com/pingcap/go-tpc/pull/15), I updated the history table. But didn't update the insert statement against table history, which will be executed in `tpcc run`. This pr fixes this bug.
