### PR TITLE
tpcc: Simplify cmd flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ For example:
 # Check consistency 
 ./bin/go-tpc tpcc --warehouses 4 check
 # Generate csv files
-./bin/go-tpc tpcc --warehouses 4 prepare --csv.output data
+./bin/go-tpc tpcc --warehouses 4 prepare --output data
 # Specified tables when generating csv files
-./bin/go-tpc tpcc --warehouses 4 prepare --csv.output data --csv.tables history,orders
+./bin/go-tpc tpcc --warehouses 4 prepare --output data --tables history,orders
 # Start pprof
-./bin/go-tpc tpcc --warehouses 4 prepare --csv.output data --pprof :10111
+./bin/go-tpc tpcc --warehouses 4 prepare --output data --pprof :10111
 ```
 
 ### TPC-H

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -39,9 +39,9 @@ var (
 )
 
 const (
-	unknownDB       = "Unknown database"
-	createDBDDL     = "CREATE DATABASE "
-	mysqlDriver     = "mysql"
+	unknownDB   = "Unknown database"
+	createDBDDL = "CREATE DATABASE "
+	mysqlDriver = "mysql"
 )
 
 func closeDB() {
@@ -93,7 +93,7 @@ func main() {
 	rootCmd.PersistentFlags().IntVarP(&threads, "threads", "T", 16, "Thread concurrency")
 	rootCmd.PersistentFlags().StringVarP(&driver, "driver", "d", "", "Database driver: mysql")
 	rootCmd.PersistentFlags().DurationVar(&totalTime, "time", 1<<63-1, "Total execution time")
-	rootCmd.PersistentFlags().IntVar(&totalCount, "count", 1000000, "Total execution count")
+	rootCmd.PersistentFlags().IntVar(&totalCount, "count", 0, "Total execution count, 0 means infinite")
 	rootCmd.PersistentFlags().BoolVar(&dropData, "dropdata", false, "Cleanup data before prepare")
 	rootCmd.PersistentFlags().BoolVar(&ignoreError, "ignore-error", false, "Ignore error when running workload")
 	rootCmd.PersistentFlags().BoolVar(&silence, "silence", false, "Don't print error when running workload")

--- a/cmd/go-tpc/misc.go
+++ b/cmd/go-tpc/misc.go
@@ -51,7 +51,7 @@ func execute(ctx context.Context, w workload.Workloader, action string, index in
 		return w.Check(ctx, index)
 	}
 
-	for i := 0; i < count; i++ {
+	for i := 0; i < count || count <= 0; i++ {
 		err := w.Run(ctx, index)
 
 		select {

--- a/cmd/go-tpc/tpcc.go
+++ b/cmd/go-tpc/tpcc.go
@@ -46,9 +46,9 @@ func registerTpcc(root *cobra.Command) {
 	cmd.PersistentFlags().IntVar(&tpccConfig.Parts, "parts", 1, "Number to partition warehouses")
 	cmd.PersistentFlags().IntVar(&tpccConfig.Warehouses, "warehouses", 10, "Number of warehouses")
 	cmd.PersistentFlags().BoolVar(&tpccConfig.CheckAll, "check-all", false, "Run all consistency checks")
-	cmd.PersistentFlags().StringVar(&tpccConfig.OutputDir, "csv.output", "", "Output directory for generating csv file when preparing data")
-	cmd.PersistentFlags().StringVar(&tpccConfig.SpecifiedTables, "csv.tables", "", "Specified tables for "+
-		"generating csv file, separated by ','. Valid only if csv.output is set. If this flag is not set, generate all tables by default.")
+	cmd.PersistentFlags().StringVar(&tpccConfig.OutputDir, "output", "", "Output directory for generating csv file when preparing data")
+	cmd.PersistentFlags().StringVar(&tpccConfig.SpecifiedTables, "tables", "", "Specified tables for "+
+		"generating file, separated by ','. Valid only if output is set. If this flag is not set, generate all tables by default.")
 
 	var cmdPrepare = &cobra.Command{
 		Use:   "prepare",


### PR DESCRIPTION
Signed-off-by: mahjonp junpeng.man@gmail.com

For nowadays, go-tpc tpcc only supports generate csv format file, so we can simplify the cmd flags. In the future, when we support more output format(e.g. Rocksdb sst file), we need add another flag `-t` to specify it.