### PR TITLE
Fixed: error TPM. Added: show current TPM

### DIFF
--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -32,6 +32,7 @@ var (
 	outputInterval time.Duration
 	isolationLevel int
 	silence        bool
+	summaryReport  bool
 	pprofAddr      string
 
 	globalDB  *sql.DB
@@ -97,6 +98,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVar(&dropData, "dropdata", false, "Cleanup data before prepare")
 	rootCmd.PersistentFlags().BoolVar(&ignoreError, "ignore-error", false, "Ignore error when running workload")
 	rootCmd.PersistentFlags().BoolVar(&silence, "silence", false, "Don't print error when running workload")
+	rootCmd.PersistentFlags().BoolVar(&summaryReport, "summary", false, "Print summary TPM only, or also print current TPM when running workload")
 	rootCmd.PersistentFlags().DurationVar(&outputInterval, "interval", 10*time.Second, "Output interval time")
 	rootCmd.PersistentFlags().IntVar(&isolationLevel, "isolation", 0, `Isolation Level 0: Default, 1: ReadUncommitted, 
 2: ReadCommitted, 3: WriteCommitted, 4: RepeatableRead, 

--- a/cmd/go-tpc/misc.go
+++ b/cmd/go-tpc/misc.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -61,8 +60,7 @@ func execute(ctx context.Context, w workload.Workloader, action string, index in
 		}
 
 		if err != nil {
-			// For TiDB, we may meet too many conflict errors, so here just ignore it
-			if !silence && !strings.Contains(err.Error(), "conflict") {
+			if !silence {
 				fmt.Printf("execute %s failed, err %v\n", action, err)
 			}
 			if !ignoreError {
@@ -90,7 +88,7 @@ func executeWorkload(ctx context.Context, w workload.Workloader, action string) 
 				ch <- struct{}{}
 				return
 			case <-ticker.C:
-				measurement.Output()
+				measurement.Output(summaryReport)
 			}
 		}
 	}()
@@ -120,5 +118,5 @@ func executeWorkload(ctx context.Context, w workload.Workloader, action string) 
 	<-ch
 
 	fmt.Println("Finished")
-	measurement.Output()
+	measurement.Output(true)
 }

--- a/pkg/measurement/hist.go
+++ b/pkg/measurement/hist.go
@@ -55,6 +55,12 @@ func (h *histogram) Measure(latency time.Duration) {
 	h.bucketCount[i] += 1
 }
 
+func (h *histogram) Empty() bool {
+	h.m.Lock()
+	defer h.m.Unlock()
+	return h.count == 0
+}
+
 func (h *histogram) Summary() string {
 	res := h.getInfo()
 


### PR DESCRIPTION
Signed-off-by: Liu Cong <innerr@gmail.com>

1, The TPM was not correct, especially happened on error TPM, it caused by the incorrect `start-time` of `hist` , this PR fixed that

2, This PR added a param `--summary`:
  - When it's true, print summary measurements on each tick
  - When it's false(by default), print current measurements on each tick, and print summary's on each 10 ticks

3, Print `conflicted` errors