### PR TITLE
TPCH: set default sf to 1

### DIFF
--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -90,7 +90,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVarP(&user, "user", "U", "root", "Database user")
 	rootCmd.PersistentFlags().StringVarP(&password, "password", "p", "", "Database password")
 	rootCmd.PersistentFlags().IntVarP(&port, "port", "P", 4000, "Database port")
-	rootCmd.PersistentFlags().IntVarP(&threads, "threads", "T", 16, "Thread concurrency")
+	rootCmd.PersistentFlags().IntVarP(&threads, "threads", "T", 1, "Thread concurrency")
 	rootCmd.PersistentFlags().StringVarP(&driver, "driver", "d", "", "Database driver: mysql")
 	rootCmd.PersistentFlags().DurationVar(&totalTime, "time", 1<<63-1, "Total execution time")
 	rootCmd.PersistentFlags().IntVar(&totalCount, "count", 0, "Total execution count, 0 means infinite")

--- a/cmd/go-tpc/tpch.go
+++ b/cmd/go-tpc/tpch.go
@@ -36,7 +36,7 @@ func registerTpch(root *cobra.Command) {
 
 	cmd.PersistentFlags().IntVar(&tpchConfig.ScaleFactor,
 		"sf",
-		0,
+		1,
 		"scale factor")
 
 	cmd.PersistentFlags().BoolVar(&tpchConfig.EnableOutputCheck,

--- a/tpch/workload.go
+++ b/tpch/workload.go
@@ -115,6 +115,7 @@ func (w Workloader) Run(ctx context.Context, threadID int) error {
 
 	start := time.Now()
 	rows, err := s.Conn.QueryContext(ctx, query)
+	defer rows.Close()
 	measurement.Measure(queryName, time.Now().Sub(start), err)
 
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

This pr sets the default value of sf to 1 and fix a bug which cause tpch workload hangs when close db conn.