### PR TITLE
Add option to create tiflash replica in TPC-H

### DIFF
--- a/cmd/go-tpc/tpch.go
+++ b/cmd/go-tpc/tpch.go
@@ -44,6 +44,11 @@ func registerTpch(root *cobra.Command) {
 		false,
 		"Check output data, only when the scale factor equals 1")
 
+	cmd.PersistentFlags().BoolVar(&tpchConfig.CreateTiFlashReplica,
+		"tiflash",
+		false,
+		"Create tiflash replica")
+
 	var cmdPrepare = &cobra.Command{
 		Use:   "prepare",
 		Short: "Prepare data for the workload",

--- a/cmd/go-tpc/tpch.go
+++ b/cmd/go-tpc/tpch.go
@@ -44,11 +44,6 @@ func registerTpch(root *cobra.Command) {
 		false,
 		"Check output data, only when the scale factor equals 1")
 
-	cmd.PersistentFlags().BoolVar(&tpchConfig.CreateTiFlashReplica,
-		"tiflash",
-		false,
-		"Create tiflash replica")
-
 	var cmdPrepare = &cobra.Command{
 		Use:   "prepare",
 		Short: "Prepare data for the workload",
@@ -56,6 +51,11 @@ func registerTpch(root *cobra.Command) {
 			executeTpch("prepare", args)
 		},
 	}
+
+	cmdPrepare.PersistentFlags().BoolVar(&tpchConfig.CreateTiFlashReplica,
+		"tiflash",
+		false,
+		"Create tiflash replica")
 
 	var cmdRun = &cobra.Command{
 		Use:   "run",

--- a/tpch/dbgen/driver.go
+++ b/tpch/dbgen/driver.go
@@ -107,6 +107,7 @@ func DbGen(loaders map[Table]Loader) error {
 	}
 
 	for _, i := range []Table{TNation, TRegion, TCust, TSupp, TPartPsupp, TOrderLine} {
+		fmt.Printf("generating %s\n", tDefs[i].comment)
 		rowCnt := tDefs[i].base
 		if i < TNation {
 			rowCnt *= scale
@@ -114,6 +115,7 @@ func DbGen(loaders map[Table]Loader) error {
 		if err := genTbl(i, 1, rowCnt); err != nil {
 			return fmt.Errorf("fail to generate %s, err: %v", tDefs[i].name, err)
 		}
+		fmt.Printf("generate %s done\n", tDefs[i].comment)
 	}
 	return nil
 }

--- a/tpch/ddl.go
+++ b/tpch/ddl.go
@@ -11,6 +11,13 @@ func (w *Workloader) createTableDDL(ctx context.Context, query string, tableName
 	if _, err := s.Conn.ExecContext(ctx, query); err != nil {
 		return err
 	}
+	if w.cfg.CreateTiFlashReplica {
+		fmt.Printf("creating tiflash replica for %s\n", tableName)
+		replicaSQL := fmt.Sprintf("ALTER TABLE %s SET TIFLASH REPLICA 1", tableName)
+		if _, err := s.Conn.ExecContext(ctx, replicaSQL); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/tpch/workload.go
+++ b/tpch/workload.go
@@ -18,11 +18,12 @@ const stateKey = contextKey("tpch")
 
 // Config is the configuration for tpch workload
 type Config struct {
-	DBName            string
-	RawQueries        string
-	QueryNames        []string
-	ScaleFactor       int
-	EnableOutputCheck bool
+	DBName               string
+	RawQueries           string
+	QueryNames           []string
+	ScaleFactor          int
+	EnableOutputCheck    bool
+	CreateTiFlashReplica bool
 }
 
 type tpchState struct {


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <jayson.hjs@gmail.com>

A an option "--tiflash" support creating tiflash replica when loading tpc-h dataset.