### PR TITLE
Add options to analyze tables after tpc-h data loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ If you want to import tpcc data into TiDB, please refer to [import-to-tidb](docs
 ```bash
 # Prepare data with scale factor 1
 ./bin/go-tpc tpch --sf=1 prepare
+# Prepare data with scale factor 1, create tiflash replica, and analyze table after data loaded
+./bin/go-tpc tpch --sf 1 --analyze --tiflash prepare
 # Run TPCH workloads with result checking
 ./bin/go-tpc tpch --sf=1 --check=true run
 # Run TPCH workloads without result checking

--- a/cmd/go-tpc/tpch.go
+++ b/cmd/go-tpc/tpch.go
@@ -57,6 +57,24 @@ func registerTpch(root *cobra.Command) {
 		false,
 		"Create tiflash replica")
 
+	cmdPrepare.PersistentFlags().BoolVar(&tpchConfig.AnalyzeTable.Enable,
+		"analyze",
+		false,
+		"After data loaded, analyze table to collect column statistics")
+	// https://pingcap.com/docs/stable/reference/performance/statistics/#control-analyze-concurrency
+	cmdPrepare.PersistentFlags().IntVar(&tpchConfig.AnalyzeTable.BuildStatsConcurrency,
+		"tidb_build_stats_concurrency",
+		4,
+		"tidb_build_stats_concurrency param for analyze jobs")
+	cmdPrepare.PersistentFlags().IntVar(&tpchConfig.AnalyzeTable.DistsqlScanConcurrency,
+		"tidb_distsql_scan_concurrency",
+		15,
+		"tidb_distsql_scan_concurrency param for analyze jobs")
+	cmdPrepare.PersistentFlags().IntVar(&tpchConfig.AnalyzeTable.IndexSerialScanConcurrency,
+		"tidb_index_serial_scan_concurrency",
+		1,
+		"tidb_index_serial_scan_concurrency param for analyze jobs")
+
 	var cmdRun = &cobra.Command{
 		Use:   "run",
 		Short: "Run workload",

--- a/tpch/ddl.go
+++ b/tpch/ddl.go
@@ -5,6 +5,12 @@ import (
 	"fmt"
 )
 
+var allTables []string
+
+func init() {
+	allTables = []string{"lineitem", "partsupp", "supplier", "part", "orders", "customer", "region", "nation"}
+}
+
 func (w *Workloader) createTableDDL(ctx context.Context, query string, tableName string, action string) error {
 	s := w.getState(ctx)
 	fmt.Printf("%s %s\n", action, tableName)
@@ -154,11 +160,8 @@ CREATE TABLE IF NOT EXISTS lineitem (
 
 func (w *Workloader) dropTable(ctx context.Context) error {
 	s := w.getState(ctx)
-	tables := []string{
-		"lineitem", "partsupp", "supplier", "part", "orders", "customer", "region", "nation",
-	}
 
-	for _, tbl := range tables {
+	for _, tbl := range allTables {
 		fmt.Printf("DROP TABLE IF EXISTS %s\n", tbl)
 		if _, err := s.Conn.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tbl)); err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

In `tpch prepare`, add some options to support automatically analyze tables after data loaded.