### PR TITLE
tpcc: add wait times on each transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ For example:
 ./bin/go-tpc tpcc --warehouses 4 --parts 4 prepare
 # Run TPCC workloads
 ./bin/go-tpc tpcc --warehouses 4 run
+# Run TPCC involving wait times(keying time and thinking time) on every transactions
+./bin/go-tpc tpcc --warehouses 4 run --keying --thinking
 # Cleanup 
 ./bin/go-tpc tpcc --warehouses 4 cleanup
 # Check consistency 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ For example:
 ./bin/go-tpc tpcc --warehouses 4 --parts 4 prepare
 # Run TPCC workloads
 ./bin/go-tpc tpcc --warehouses 4 run
-# Run TPCC involving wait times(keying time and thinking time) on every transactions
-./bin/go-tpc tpcc --warehouses 4 run --keying --thinking
+# Run TPCC including wait times(keying & thinking time) on every transactions
+./bin/go-tpc tpcc --warehouses 4 run --wait
 # Cleanup 
 ./bin/go-tpc tpcc --warehouses 4 cleanup
 # Check consistency 

--- a/cmd/go-tpc/tpcc.go
+++ b/cmd/go-tpc/tpcc.go
@@ -84,6 +84,8 @@ func registerTpcc(root *cobra.Command) {
 			executeTpcc("run")
 		},
 	}
+	cmdRun.PersistentFlags().BoolVar(&tpccConfig.Keying, "keying", false, "whether to involve keying time")
+	cmdRun.PersistentFlags().BoolVar(&tpccConfig.Thinking, "thinking", false, "whether to involve thinking time")
 
 	var cmdCleanup = &cobra.Command{
 		Use:   "cleanup",

--- a/cmd/go-tpc/tpcc.go
+++ b/cmd/go-tpc/tpcc.go
@@ -84,8 +84,7 @@ func registerTpcc(root *cobra.Command) {
 			executeTpcc("run")
 		},
 	}
-	cmdRun.PersistentFlags().BoolVar(&tpccConfig.Keying, "keying", false, "whether to involve keying time")
-	cmdRun.PersistentFlags().BoolVar(&tpccConfig.Thinking, "thinking", false, "whether to involve thinking time")
+	cmdRun.PersistentFlags().BoolVar(&tpccConfig.Wait, "wait", false, "including keying & thinking time described on TPC-C Standard Specification")
 
 	var cmdCleanup = &cobra.Command{
 		Use:   "cleanup",

--- a/pkg/measurement/hist.go
+++ b/pkg/measurement/hist.go
@@ -23,7 +23,7 @@ type histInfo struct {
 	count   int64
 	ops     float64
 	avg     int64
-	p95     int64
+	p90     int64
 	p99     int64
 	p999    int64
 }
@@ -70,7 +70,7 @@ func (h *histogram) Summary() string {
 	buf.WriteString(fmt.Sprintf("TPM: %.1f, ", res.ops*60))
 	buf.WriteString(fmt.Sprintf("Sum(ms): %d, ", res.sum))
 	buf.WriteString(fmt.Sprintf("Avg(ms): %d, ", res.avg))
-	buf.WriteString(fmt.Sprintf("95th(ms): %d, ", res.p95))
+	buf.WriteString(fmt.Sprintf("90th(ms): %d, ", res.p90))
 	buf.WriteString(fmt.Sprintf("99th(ms): %d, ", res.p99))
 	buf.WriteString(fmt.Sprintf("99.9th(ms): %d", res.p999))
 
@@ -80,7 +80,7 @@ func (h *histogram) Summary() string {
 func (h *histogram) getInfo() histInfo {
 	elapsed := time.Now().Sub(h.startTime).Seconds()
 
-	per95 := int64(0)
+	per90 := int64(0)
 	per99 := int64(0)
 	per999 := int64(0)
 	opCount := int64(0)
@@ -96,8 +96,8 @@ func (h *histogram) getInfo() histInfo {
 	for i, hc := range h.bucketCount {
 		opCount += hc
 		per := float64(opCount) / float64(count)
-		if per95 == 0 && per >= 0.95 {
-			per95 = int64(h.buckets[i])
+		if per90 == 0 && per >= 0.90 {
+			per90 = int64(h.buckets[i])
 		}
 
 		if per99 == 0 && per >= 0.99 {
@@ -116,7 +116,7 @@ func (h *histogram) getInfo() histInfo {
 		count:   count,
 		ops:     ops,
 		avg:     avg,
-		p95:     per95,
+		p90:     per90,
 		p99:     per99,
 		p999:    per999,
 	}

--- a/tpcc/workload.go
+++ b/tpcc/workload.go
@@ -52,9 +52,8 @@ type Config struct {
 	Isolation  int
 	CheckAll   bool
 
-	// whether to involve keying time and thinking time
-	Keying   bool
-	Thinking bool
+	// whether to involve wait times(keying time&thinking time)
+	Wait bool
 
 	// for prepare sub-command only
 	OutputType      string
@@ -243,7 +242,7 @@ func (w *Workloader) Run(ctx context.Context, threadID int) error {
 	// and must be a minimum of 18 seconds for New Order,
 	// 3 seconds for Payment,
 	// and 2 seconds each for Order-Status, Delivery, and Stock-Level.
-	if w.cfg.Keying {
+	if w.cfg.Wait {
 		time.Sleep(time.Duration(txn.keyingTime * float64(time.Second)))
 	}
 
@@ -255,14 +254,13 @@ func (w *Workloader) Run(ctx context.Context, threadID int) error {
 	// 5.2.5.4, For each transaction type, think time is taken independently from a negative exponential distribution.
 	// Think time, T t , is computed from the following equation: Tt = -log(r) * (mean think time),
 	// r = random number uniformly distributed between 0 and 1
-	if w.cfg.Thinking {
+	if w.cfg.Wait {
 		thinkTime := -math.Log(rand.Float64()) * txn.thinkingTime
 		if thinkTime > txn.thinkingTime*10 {
 			thinkTime = txn.thinkingTime * 10
 		}
 		time.Sleep(time.Duration(thinkTime * float64(time.Second)))
 	}
-
 	// TODO: add check
 	return err
 }


### PR DESCRIPTION
Add Keying Time and Thinking Time between txn execution and two flags.

``` bash
Usage:
  go-tpc tpcc run [flags]

Flags:
  -h, --help   help for run
      --wait   including keying & thinking time described on TPC-C Standard Specification
```


For example.

```
./bin/go-tpc tpcc --warehouses 4 run --wait
```