### PR TITLE
Workload: customize statistics output for different workload

### DIFF
--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -31,7 +31,6 @@ var (
 	outputInterval time.Duration
 	isolationLevel int
 	silence        bool
-	summaryReport  bool
 	pprofAddr      string
 	maxProcs       int
 
@@ -97,7 +96,6 @@ func main() {
 	rootCmd.PersistentFlags().BoolVar(&dropData, "dropdata", false, "Cleanup data before prepare")
 	rootCmd.PersistentFlags().BoolVar(&ignoreError, "ignore-error", false, "Ignore error when running workload")
 	rootCmd.PersistentFlags().BoolVar(&silence, "silence", false, "Don't print error when running workload")
-	rootCmd.PersistentFlags().BoolVar(&summaryReport, "summary", false, "Print summary TPM only, or also print current TPM when running workload")
 	rootCmd.PersistentFlags().DurationVar(&outputInterval, "interval", 10*time.Second, "Output interval time")
 	rootCmd.PersistentFlags().IntVar(&isolationLevel, "isolation", 0, `Isolation Level 0: Default, 1: ReadUncommitted, 
 2: ReadCommitted, 3: WriteCommitted, 4: RepeatableRead, 

--- a/cmd/go-tpc/misc.go
+++ b/cmd/go-tpc/misc.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pingcap/go-tpc/pkg/measurement"
 	"github.com/pingcap/go-tpc/pkg/workload"
 )
 
@@ -94,7 +93,7 @@ func executeWorkload(ctx context.Context, w workload.Workloader, action string) 
 				ch <- struct{}{}
 				return
 			case <-ticker.C:
-				measurement.Output(summaryReport)
+				w.OutputStats(false)
 			}
 		}
 	}()
@@ -120,5 +119,5 @@ func executeWorkload(ctx context.Context, w workload.Workloader, action string) 
 	<-ch
 
 	fmt.Println("Finished")
-	measurement.Output(true)
+	w.OutputStats(true)
 }

--- a/pkg/measurement/hist.go
+++ b/pkg/measurement/hist.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-type histogram struct {
+type Histogram struct {
 	m           sync.RWMutex
 	bucketCount []int64
 	buckets     []int
@@ -17,19 +17,19 @@ type histogram struct {
 	startTime   time.Time
 }
 
-type histInfo struct {
-	elapsed float64
-	sum     int64
-	count   int64
-	ops     float64
-	avg     int64
-	p90     int64
-	p99     int64
-	p999    int64
+type HistInfo struct {
+	Elapsed float64
+	Sum     int64
+	Count   int64
+	Ops     float64
+	Avg     int64
+	P90     int64
+	P99     int64
+	P999    int64
 }
 
-func newHistogram() *histogram {
-	h := new(histogram)
+func NewHistogram() *Histogram {
+	h := new(Histogram)
 	h.startTime = time.Now()
 	// Unit 1ms
 	h.buckets = []int{1, 2, 4, 8, 9, 12, 16, 20, 24, 32, 40, 48, 64, 80,
@@ -38,7 +38,7 @@ func newHistogram() *histogram {
 	return h
 }
 
-func (h *histogram) Measure(latency time.Duration) {
+func (h *Histogram) Measure(latency time.Duration) {
 	n := int64(latency / time.Millisecond)
 
 	i := sort.SearchInts(h.buckets, int(n))
@@ -55,29 +55,29 @@ func (h *histogram) Measure(latency time.Duration) {
 	h.bucketCount[i] += 1
 }
 
-func (h *histogram) Empty() bool {
+func (h *Histogram) Empty() bool {
 	h.m.Lock()
 	defer h.m.Unlock()
 	return h.count == 0
 }
 
-func (h *histogram) Summary() string {
-	res := h.getInfo()
+func (h *Histogram) Summary() string {
+	res := h.GetInfo()
 
 	buf := new(bytes.Buffer)
-	buf.WriteString(fmt.Sprintf("Takes(s): %.1f, ", res.elapsed))
-	buf.WriteString(fmt.Sprintf("Count: %d, ", res.count))
-	buf.WriteString(fmt.Sprintf("TPM: %.1f, ", res.ops*60))
-	buf.WriteString(fmt.Sprintf("Sum(ms): %d, ", res.sum))
-	buf.WriteString(fmt.Sprintf("Avg(ms): %d, ", res.avg))
-	buf.WriteString(fmt.Sprintf("90th(ms): %d, ", res.p90))
-	buf.WriteString(fmt.Sprintf("99th(ms): %d, ", res.p99))
-	buf.WriteString(fmt.Sprintf("99.9th(ms): %d", res.p999))
+	buf.WriteString(fmt.Sprintf("Takes(s): %.1f, ", res.Elapsed))
+	buf.WriteString(fmt.Sprintf("Count: %d, ", res.Count))
+	buf.WriteString(fmt.Sprintf("TPM: %.1f, ", res.Ops*60))
+	buf.WriteString(fmt.Sprintf("Sum(ms): %d, ", res.Sum))
+	buf.WriteString(fmt.Sprintf("Avg(ms): %d, ", res.Avg))
+	buf.WriteString(fmt.Sprintf("90th(ms): %d, ", res.P90))
+	buf.WriteString(fmt.Sprintf("99th(ms): %d, ", res.P99))
+	buf.WriteString(fmt.Sprintf("99.9th(ms): %d", res.P999))
 
 	return buf.String()
 }
 
-func (h *histogram) getInfo() histInfo {
+func (h *Histogram) GetInfo() HistInfo {
 	elapsed := time.Now().Sub(h.startTime).Seconds()
 
 	per90 := int64(0)
@@ -110,15 +110,15 @@ func (h *histogram) getInfo() histInfo {
 	}
 
 	ops := float64(count) / elapsed
-	info := histInfo{
-		elapsed: elapsed,
-		sum:     sum,
-		count:   count,
-		ops:     ops,
-		avg:     avg,
-		p90:     per90,
-		p99:     per99,
-		p999:    per999,
+	info := HistInfo{
+		Elapsed: elapsed,
+		Sum:     sum,
+		Count:   count,
+		Ops:     ops,
+		Avg:     avg,
+		P90:     per90,
+		P99:     per99,
+		P999:    per999,
 	}
 	return info
 }

--- a/pkg/measurement/hist_test.go
+++ b/pkg/measurement/hist_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestHist(t *testing.T) {
-	h := newHistogram()
+	h := NewHistogram()
 	for i := 0; i < 100; i++ {
 		n := rand.Intn(100)
 		h.Measure(time.Millisecond * time.Duration(n))

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -14,5 +14,6 @@ type Workloader interface {
 	Run(ctx context.Context, threadID int) error
 	Cleanup(ctx context.Context, threadID int) error
 	Check(ctx context.Context, threadID int) error
+	OutputStats(ifSummaryReport bool)
 	DBName() string
 }

--- a/tpcc/csv.go
+++ b/tpcc/csv.go
@@ -149,6 +149,9 @@ func (c *CSVWorkLoader) Check(_ context.Context, _ int) error {
 	return nil
 }
 
+// OutputStats just do nothing
+func (c *CSVWorkLoader) OutputStats(_ bool) {}
+
 func (c *CSVWorkLoader) DBName() string {
 	return c.cfg.DBName
 }


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

Currently, TPC-C and TPCH share the same style `Summary` output but provide custom output are preferred because, on TPC-H, we only care about the average duration of each SQLs, total duration, and other metrics we don't care.

So, to TPC-C, I change the summary output follow the style:

```
[Summary] DELIVERY - Takes(s): 152.1, Count: 43, TPM: 17.0, Sum(ms): 1553, Avg(ms): 36, 90th(ms): 40, 99th(ms): 48, 99.9th(ms): 48
[Summary] DELIVERY_ERR - Takes(s): 152.1, Count: 1, TPM: 0.4, Sum(ms): 32, Avg(ms): 32, 90th(ms): 32, 99th(ms): 32, 99.9th(ms): 32
...
[Summary] KEYINGTIME-DELIVERY - 2.0s
[Summary] KEYINGTIME-NEW_ORDER - 18.0s
[Summary] KEYINGTIME-ORDER_STATUS - 2.0s
[Summary] KEYINGTIME-PAYMENT - 3.0s
[Summary] KEYINGTIME-STOCK_LEVEL - 2.0s
[Summary] THINKINGTIME-DELIVERY - 2.0s
...
```

And for TPC-H, it is the below format:

```
[Current] Q1: 2.39s
[Current] Q2: 1.06s
[Current] Q3: 2.05s
[Current] Q4: 1.13s
[Current] Q5: 24.59s
[Current] Q6: 0.88s
[Current] Q7: 1.39s
[Current] Q8: 2.08s
Finished
[Summary] Q1: 2.39s
[Summary] Q10: 1.13s
[Summary] Q11: 1.11s
[Summary] Q12: 1.03s
[Summary] Q2: 1.06s
[Summary] Q3: 2.05s
[Summary] Q4: 1.13s
[Summary] Q5: 24.59s
[Summary] Q6: 0.88s
[Summary] Q7: 1.39s
[Summary] Q8: 2.08s
[Summary] Q9: 18.08s
```

With this PR, I remove the `summaryReport` flag, because, in the previous way, it's used to control whether to print real-time metrics or summary metrics in some intervals, but real-time metrics are enough to let us known the trending of TPM of transactions, so I remove it in the PR and always print real-time metrics on screen.