### PR TITLE
TPCH: fix a panic issue

### DIFF
--- a/tpcc/check.go
+++ b/tpcc/check.go
@@ -72,7 +72,7 @@ func (w *Workloader) checkCondition1(ctx context.Context, warehouse int) error {
 
 	rows, err := s.Conn.QueryContext(ctx, query, warehouse)
 	if err != nil {
-		return fmt.Errorf("Exec %s failed %v", query, err)
+		return fmt.Errorf("exec %s failed %v", query, err)
 	}
 	defer rows.Close()
 
@@ -107,7 +107,7 @@ func (w *Workloader) checkCondition2(ctx context.Context, warehouse int) error {
 
 	rows, err := s.Conn.QueryContext(ctx, query, warehouse, warehouse, warehouse)
 	if err != nil {
-		return fmt.Errorf("Exec %s failed %v", query, err)
+		return fmt.Errorf("exec %s failed %v", query, err)
 	}
 	defer rows.Close()
 
@@ -137,7 +137,7 @@ func (w *Workloader) checkCondition3(ctx context.Context, warehouse int) error {
 
 	rows, err := s.Conn.QueryContext(ctx, query, warehouse)
 	if err != nil {
-		return fmt.Errorf("Exec %s failed %v", query, err)
+		return fmt.Errorf("exec %s failed %v", query, err)
 	}
 	defer rows.Close()
 
@@ -167,7 +167,7 @@ func (w *Workloader) checkCondition4(ctx context.Context, warehouse int) error {
 
 	rows, err := s.Conn.QueryContext(ctx, query, warehouse, warehouse)
 	if err != nil {
-		return fmt.Errorf("Exec %s failed %v", query, err)
+		return fmt.Errorf("exec %s failed %v", query, err)
 	}
 	defer rows.Close()
 
@@ -197,7 +197,7 @@ func (w *Workloader) checkCondition5(ctx context.Context, warehouse int) error {
 
 	rows, err := s.Conn.QueryContext(ctx, query, warehouse)
 	if err != nil {
-		return fmt.Errorf("Exec %s failed %v", query, err)
+		return fmt.Errorf("exec %s failed %v", query, err)
 	}
 	defer rows.Close()
 
@@ -234,7 +234,7 @@ WHERE T.o_ol_cnt != T.order_line_count`
 
 	rows, err := s.Conn.QueryContext(ctx, query, warehouse)
 	if err != nil {
-		return fmt.Errorf("Exec %s failed %v", query, err)
+		return fmt.Errorf("exec %s failed %v", query, err)
 	}
 	defer rows.Close()
 
@@ -265,7 +265,7 @@ func (w *Workloader) checkCondition7(ctx context.Context, warehouse int) error {
 
 	rows, err := s.Conn.QueryContext(ctx, query, warehouse)
 	if err != nil {
-		return fmt.Errorf("Exec %s failed %v", query, err)
+		return fmt.Errorf("exec %s failed %v", query, err)
 	}
 	defer rows.Close()
 
@@ -295,7 +295,7 @@ func (w *Workloader) checkCondition8(ctx context.Context, warehouse int) error {
 
 	rows, err := s.Conn.QueryContext(ctx, query, warehouse)
 	if err != nil {
-		return fmt.Errorf("Exec %s failed %v", query, err)
+		return fmt.Errorf("exec %s failed %v", query, err)
 	}
 	defer rows.Close()
 
@@ -325,7 +325,7 @@ func (w *Workloader) checkCondition9(ctx context.Context, warehouse int) error {
 
 	rows, err := s.Conn.QueryContext(ctx, query, warehouse, warehouse)
 	if err != nil {
-		return fmt.Errorf("Exec %s failed %v", query, err)
+		return fmt.Errorf("exec %s failed %v", query, err)
 	}
 	defer rows.Close()
 
@@ -370,7 +370,7 @@ func (w *Workloader) checkCondition10(ctx context.Context, warehouse int) error 
 
 	rows, err := s.Conn.QueryContext(ctx, query, warehouse, warehouse, warehouse)
 	if err != nil {
-		return fmt.Errorf("Exec %s failed %v", query, err)
+		return fmt.Errorf("exec %s failed %v", query, err)
 	}
 	defer rows.Close()
 
@@ -411,7 +411,7 @@ WHERE c_w_id = ? AND order_count - 2100 != new_order_count`
 
 	rows, err := s.Conn.QueryContext(ctx, query, warehouse)
 	if err != nil {
-		return fmt.Errorf("Exec %s failed %v", query, err)
+		return fmt.Errorf("exec %s failed %v", query, err)
 	}
 	defer rows.Close()
 
@@ -444,7 +444,7 @@ func (w *Workloader) checkCondition12(ctx context.Context, warehouse int) error 
 		WHERE c1+c_ytd_payment <> sm`
 	rows, err := s.Conn.QueryContext(ctx, query, warehouse, warehouse)
 	if err != nil {
-		return fmt.Errorf("Exec %s failed %v", query, err)
+		return fmt.Errorf("exec %s failed %v", query, err)
 	}
 	defer rows.Close()
 

--- a/tpch/workload.go
+++ b/tpch/workload.go
@@ -152,6 +152,9 @@ func (w Workloader) Run(ctx context.Context, threadID int) error {
 
 	start := time.Now()
 	rows, err := s.Conn.QueryContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("execute query %s failed %v", query, err)
+	}
 	defer rows.Close()
 	w.measurement.Measure(queryName, time.Now().Sub(start), err)
 


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

Here is a tiup bench TPCH panic log:

```log
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4f8832]

goroutine 39 [running]:
database/sql.(*Rows).close(0x0, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/database/sql/sql.go:3063 +0x72
database/sql.(*Rows).Close(0x0, 0x30, 0x8beb00)
        /usr/local/go/src/database/sql/sql.go:3059 +0x33
github.com/pingcap/go-tpc/tpch.Workloader.Run(0xc0001b6000, 0xe64d80, 0x9c28c0, 0xc00026e090, 0x3, 0x9b8cc0, 0xc0000b3320)
        /go/pkg/mod/github.com/pingcap/go-tpc@v1.0.4-0.20200511044254-883c1a10d555/tpch/workload.go:154 +0x4d7
main.execute(0x9c28c0, 0xc00026e090, 0x9c71e0, 0xc000152050, 0x8fb1ae, 0x3, 0x3, 0x0, 0x0)
        /home/jenkins/agent/workspace/bench-tiup-mirror-update/components/bench/misc.go:60 +0x34f
main.executeWorkload.func2(0xc000150020, 0x9c2880, 0xc0001541e0, 0x9c71e0, 0xc000152050, 0x8fb1ae, 0x3, 0x3)
        /home/jenkins/agent/workspace/bench-tiup-mirror-update/components/bench/misc.go:105 +0xc8
created by main.executeWorkload
        /home/jenkins/agent/workspace/bench-tiup-mirror-update/components/bench/misc.go:103 +0x16f
Error: run `/home/tmpuser/.tiup/components/bench/v0.0.2/bench` (wd:/home/tmpuser/.tiup/data/5) failed: exit status 2
```