### PR TITLE
[DNM] vertical partition stock and customer table

### DIFF
--- a/tpcc/ddl.go
+++ b/tpcc/ddl.go
@@ -6,15 +6,17 @@ import (
 )
 
 const (
-	tableItem      = "item"
-	tableCustomer  = "customer"
-	tableDistrict  = "district"
-	tableOrders    = "orders"
-	tableNewOrder  = "new_order"
-	tableOrderLine = "order_line"
-	tableHistory   = "history"
-	tableWareHouse = "warehouse"
-	tableStock     = "stock"
+	tableItem         = "item"
+	tableCustomer     = "customer"
+	tableCustomerData = "customer_data"
+	tableDistrict     = "district"
+	tableOrders       = "orders"
+	tableNewOrder     = "new_order"
+	tableOrderLine    = "order_line"
+	tableHistory      = "history"
+	tableWareHouse    = "warehouse"
+	tableStock        = "stock"
+	tableStockData    = "stock_data"
 )
 
 type ddlManager struct {
@@ -95,6 +97,7 @@ CREATE TABLE IF NOT EXISTS customer (
 	c_id INT NOT NULL, 
 	c_d_id INT NOT NULL,
 	c_w_id INT NOT NULL, 
+	c_uid BIGINT NOT NULL,
 	c_first VARCHAR(16), 
 	c_middle CHAR(2), 
 	c_last VARCHAR(16), 
@@ -112,7 +115,6 @@ CREATE TABLE IF NOT EXISTS customer (
 	c_ytd_payment DECIMAL(12,2), 
 	c_payment_cnt INT, 
 	c_delivery_cnt INT, 
-	c_data VARCHAR(500),
 	PRIMARY KEY(c_w_id, c_d_id, c_id),
 	INDEX idx_customer (c_w_id, c_d_id, c_last, c_first)
 )`
@@ -120,6 +122,18 @@ CREATE TABLE IF NOT EXISTS customer (
 	query = w.appendPartition(query, "c_w_id")
 
 	if err := w.createTableDDL(ctx, query, tableCustomer); err != nil {
+		return err
+	}
+
+	// Customer Data
+	query = `
+CREATE TABLE IF NOT EXISTS customer_data (
+	c_uid BIGINT NOT NULL,
+	c_data VARCHAR(500),
+	PRIMARY KEY(c_uid)
+)`
+
+	if err := w.createTableDDL(ctx, query, tableCustomerData); err != nil {
 		return err
 	}
 
@@ -200,7 +214,22 @@ CREATE TABLE IF NOT EXISTS orders (
 CREATE TABLE IF NOT EXISTS stock (
 	s_i_id INT NOT NULL,
 	s_w_id INT NOT NULL,
+	s_uid BIGINT NOT NULL,
 	s_quantity INT,
+	s_ytd INT, 
+	s_order_cnt INT, 
+	s_remote_cnt INT,
+	PRIMARY KEY(s_w_id, s_i_id)
+)`
+
+	query = w.appendPartition(query, "s_w_id")
+	if err := w.createTableDDL(ctx, query, tableStock); err != nil {
+		return err
+	}
+
+	query = `
+CREATE TABLE IF NOT EXISTS stock_data (
+	s_uid BIGINT NOT NULL,
 	s_dist_01 CHAR(24), 
 	s_dist_02 CHAR(24),
 	s_dist_03 CHAR(24),
@@ -210,16 +239,12 @@ CREATE TABLE IF NOT EXISTS stock (
 	s_dist_07 CHAR(24), 
 	s_dist_08 CHAR(24), 
 	s_dist_09 CHAR(24), 
-	s_dist_10 CHAR(24), 
-	s_ytd INT, 
-	s_order_cnt INT, 
-	s_remote_cnt INT,
+	s_dist_10 CHAR(24),
 	s_data VARCHAR(50),
-	PRIMARY KEY(s_w_id, s_i_id)
+	PRIMARY KEY(s_uid)
 )`
 
-	query = w.appendPartition(query, "s_w_id")
-	if err := w.createTableDDL(ctx, query, tableStock); err != nil {
+	if err := w.createTableDDL(ctx, query, tableStockData); err != nil {
 		return err
 	}
 

--- a/tpcc/workload.go
+++ b/tpcc/workload.go
@@ -197,6 +197,7 @@ func (w *Workloader) Run(ctx context.Context, threadID int) error {
 		for i := 5; i <= 15; i++ {
 			s.newOrderStmts[newOrderSelectItemSQLs[i]] = prepareStmt(ctx, s.Conn, newOrderSelectItemSQLs[i])
 			s.newOrderStmts[newOrderSelectStockSQLs[i]] = prepareStmt(ctx, s.Conn, newOrderSelectStockSQLs[i])
+			s.newOrderStmts[newOrderSelectStockDataSQLs[i]] = prepareStmt(ctx, s.Conn, newOrderSelectStockDataSQLs[i])
 			s.newOrderStmts[newOrderInsertOrderLineSQLs[i]] = prepareStmt(ctx, s.Conn, newOrderInsertOrderLineSQLs[i])
 		}
 
@@ -208,8 +209,8 @@ func (w *Workloader) Run(ctx context.Context, threadID int) error {
 			paymentSelectCustomerListByLast: prepareStmt(ctx, s.Conn, paymentSelectCustomerListByLast),
 			paymentSelectCustomerForUpdate:  prepareStmt(ctx, s.Conn, paymentSelectCustomerForUpdate),
 			paymentSelectCustomerData:       prepareStmt(ctx, s.Conn, paymentSelectCustomerData),
-			paymentUpdateCustomerWithData:   prepareStmt(ctx, s.Conn, paymentUpdateCustomerWithData),
 			paymentUpdateCustomer:           prepareStmt(ctx, s.Conn, paymentUpdateCustomer),
+			paymentUpdateCustomerData:       prepareStmt(ctx, s.Conn, paymentUpdateCustomerData),
 			paymentInsertHistory:            prepareStmt(ctx, s.Conn, paymentInsertHistory),
 		}
 


### PR DESCRIPTION
Only tested 10 warehouses, run 500 seconds.
The TPM is not stable so we only calculate written bytes per TPM.

```
vertical partition

badger_num_compaction_bytes_write{path="/tmp/tidb/kv",target_level="L0"} 1.466424324e+09
[Summary] NEW_ORDER - Takes(s): 500.0, Count: 266223, TPM: 31948.7, Sum(ms): 2435459, Avg(ms): 9, 90th(ms): 12, 99th(ms): 20, 99.9th(ms): 40

no vertical partition
badger_num_compaction_bytes_write{path="/tmp/tidb/kv",target_level="L0"} 2.422536937e+09
[Summary] NEW_ORDER - Takes(s): 500.0, Count: 252080, TPM: 30251.5, Sum(ms): 2395755, Avg(ms): 9, 90th(ms): 16, 99th(ms): 32, 99.9th(ms): 64
```

Bytes per new order transaction decreased from 9.6KB to 5.5KB (-42.7%)