### PR TITLE
Add make docker-* targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Build the go-tpc binary
+FROM golang:1.13 as builder
+
+WORKDIR /workspace
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the source
+COPY . .
+
+# Build
+RUN GOOS=linux GOARCH=amd64 make build
+
+FROM pingcap/alpine-glibc:3.10
+
+RUN apk add --no-cache \
+  dumb-init \
+  tzdata \
+  # help to setup or teardown database schemas
+  mariadb-client
+
+COPY --from=builder /workspace/bin/go-tpc /go-tpc
+
+ENTRYPOINT [ "/usr/bin/dumb-init" ]
+ENTRYPOINT ["/go-tpc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ RUN apk add --no-cache \
 COPY --from=builder /workspace/bin/go-tpc /go-tpc
 
 ENTRYPOINT [ "/usr/bin/dumb-init" ]
-ENTRYPOINT ["/go-tpc"]
+CMD ["/go-tpc"]

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ PACKAGE_LIST  := go list ./...| grep -vE "cmd"
 PACKAGES  := $$($(PACKAGE_LIST))
 FILES_TO_FMT  := $(shell find . -path -prune -o -name '*.go' -print)
 
+# Image URL to use all building/pushing image targets
+IMG ?= go-tpc:latest
+
 all: format test build
 
 format: vet fmt
@@ -28,3 +31,9 @@ mod:
 	@echo "go mod tidy"
 	GO111MODULE=on go mod tidy
 	@git diff --exit-code -- go.sum go.mod
+
+docker-build: test
+	docker build . -t ${IMG}
+
+docker-push: docker-build
+	docker push ${IMG}


### PR DESCRIPTION
This PR add a Dockerfile and support build and push docker image of go-tpc via `make docker-build` and `make docker-push`

Signed-off-by: Aylei <rayingecho@gmail.com>