### PR TITLE
tpcc: use right think time value

### DIFF
--- a/tpcc/workload.go
+++ b/tpcc/workload.go
@@ -270,7 +270,7 @@ func (w *Workloader) Run(ctx context.Context, threadID int) error {
 		if thinkTime > txn.thinkingTime*10 {
 			thinkTime = txn.thinkingTime * 10
 		}
-		time.Sleep(time.Duration(txn.keyingTime * float64(time.Second)))
+		time.Sleep(time.Duration(thinkTime * float64(time.Second)))
 		w.waitTimeMeasurement.Measure(fmt.Sprintf("thinkingTime-%s", txn.name), time.Now().Sub(start), nil)
 	}
 	// TODO: add check


### PR DESCRIPTION
current code use `keyingTime` value as think time seems be wrong

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/go-tpc/64)
<!-- Reviewable:end -->
