### PR TITLE
feature: add new flag(no-check), help skip check when tpcc prepare

### DIFF
--- a/cmd/go-tpc/misc.go
+++ b/cmd/go-tpc/misc.go
@@ -15,6 +15,9 @@ func checkPrepare(ctx context.Context, w workload.Workloader) {
 		fmt.Println("Skip preparing checking. Please load CSV data into database and check later.")
 		return
 	}
+	if w.Name() == "tpcc" && tpccConfig.NoCheck {
+		return
+	}
 
 	var wg sync.WaitGroup
 	wg.Add(threads)

--- a/cmd/go-tpc/tpcc.go
+++ b/cmd/go-tpc/tpcc.go
@@ -30,7 +30,6 @@ func executeTpcc(action string) {
 	tpccConfig.DBName = dbName
 	tpccConfig.Threads = threads
 	tpccConfig.Isolation = isolationLevel
-
 	var (
 		w   workload.Workloader
 		err error
@@ -68,7 +67,6 @@ func registerTpcc(root *cobra.Command) {
 	cmd.PersistentFlags().IntVar(&tpccConfig.Parts, "parts", 1, "Number to partition warehouses")
 	cmd.PersistentFlags().IntVar(&tpccConfig.Warehouses, "warehouses", 10, "Number of warehouses")
 	cmd.PersistentFlags().BoolVar(&tpccConfig.CheckAll, "check-all", false, "Run all consistency checks")
-
 	var cmdPrepare = &cobra.Command{
 		Use:   "prepare",
 		Short: "Prepare data for TPCC",
@@ -76,6 +74,7 @@ func registerTpcc(root *cobra.Command) {
 			executeTpcc("prepare")
 		},
 	}
+	cmdPrepare.PersistentFlags().BoolVar(&tpccConfig.NoCheck, "no-check", false, "TPCC prepare check, default false")
 	cmdPrepare.PersistentFlags().StringVar(&tpccConfig.OutputType, "output-type", "", "Output file type."+
 		" If empty, then load data to db. Current only support csv")
 	cmdPrepare.PersistentFlags().StringVar(&tpccConfig.OutputDir, "output-dir", "", "Output directory for generating file if specified")

--- a/tpcc/workload.go
+++ b/tpcc/workload.go
@@ -53,6 +53,7 @@ type Config struct {
 	UseFK      bool
 	Isolation  int
 	CheckAll   bool
+	NoCheck    bool
 
 	// whether to involve wait times(keying time&thinking time)
 	Wait bool


### PR DESCRIPTION
Reasons: tpcc prepare check sometimes aren't necessary.
Changes: 1.add new flag(no-check) in cmd. 2.add new field(NoCheck) in tpccConfig 3.check tpccConfig.NoCheck in misc.go: checkPrepare


Signed-off-by: Cadmus <CadmusJiang@gmail.com>