### PR TITLE
tpcc: refresh conn if pingContext fails

### DIFF
--- a/pkg/workload/base.go
+++ b/pkg/workload/base.go
@@ -19,7 +19,7 @@ type TpcState struct {
 	Buf *util.BufAllocator
 }
 
-func (t *TpcState) RereshConn(ctx context.Context) error {
+func (t *TpcState) RefreshConn(ctx context.Context) error {
 	conn, err := t.DB.Conn(ctx)
 	if err != nil {
 		return err

--- a/pkg/workload/base.go
+++ b/pkg/workload/base.go
@@ -11,11 +11,21 @@ import (
 
 // TpcState saves state for each thread
 type TpcState struct {
+	DB   *sql.DB
 	Conn *sql.Conn
 
 	R *rand.Rand
 
 	Buf *util.BufAllocator
+}
+
+func (t *TpcState) RereshConn(ctx context.Context) error {
+	conn, err := t.DB.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	t.Conn = conn
+	return nil
 }
 
 // NewTpcState creates a base TpcState
@@ -32,6 +42,7 @@ func NewTpcState(ctx context.Context, db *sql.DB) *TpcState {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	s := &TpcState{
+		DB:   db,
 		Conn: conn,
 		R:    r,
 		Buf:  util.NewBufAllocator(),

--- a/tpcc/workload.go
+++ b/tpcc/workload.go
@@ -194,7 +194,7 @@ func (w *Workloader) Run(ctx context.Context, threadID int) error {
 	s := getTPCCState(ctx)
 	refreshConn := false
 	if err := s.Conn.PingContext(ctx); err != nil {
-		if err := s.RereshConn(ctx); err != nil {
+		if err := s.RefreshConn(ctx); err != nil {
 			return err
 		}
 		refreshConn = true

--- a/tpcc/workload.go
+++ b/tpcc/workload.go
@@ -192,8 +192,14 @@ func getTPCCState(ctx context.Context) *tpccState {
 // Run implements Workloader interface
 func (w *Workloader) Run(ctx context.Context, threadID int) error {
 	s := getTPCCState(ctx)
-
-	if s.newOrderStmts == nil {
+	refreshConn := false
+	if err := s.Conn.PingContext(ctx); err != nil {
+		if err := s.RereshConn(ctx); err != nil {
+			return err
+		}
+		refreshConn = true
+	}
+	if s.newOrderStmts == nil || refreshConn {
 		s.newOrderStmts = map[string]*sql.Stmt{
 			newOrderSelectCustomer: prepareStmt(ctx, s.Conn, newOrderSelectCustomer),
 			newOrderSelectDistrict: prepareStmt(ctx, s.Conn, newOrderSelectDistrict),


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

This PR fixes the invalid connection error when the tidb-server is killed

```
[mysql] 2021/03/27 07:50:25 packets.go:36: unexpected EOF
[2021-03-27 07:50:25] execute run failed, err invalid connection
[2021-03-27 07:50:25] execute run failed, err invalid connection
[2021-03-27 07:50:25] execute run failed, err invalid connection
execute run failed, err invalid connection
execute run failed, err invalid connection
execute run failed, err invalid connection
[2021-03-27 07:50:25] execute run failed, err invalid connection
execute run failed, err invalid connection
[mysql] 2021/03/27 07:50:25 packets.go:36: unexpected EOF
[mysql] 2021/03/27 07:50:25 packets.go:36: unexpected EOF
```