### PR TITLE
tpcc: ignore the non-first `Duplicated entry` error

### DIFF
--- a/cmd/go-tpc/tpcc.go
+++ b/cmd/go-tpc/tpcc.go
@@ -91,8 +91,8 @@ func registerTpcc(root *cobra.Command) {
 	cmdPrepare.PersistentFlags().StringVar(&tpccConfig.OutputDir, "output-dir", "", "Output directory for generating file if specified")
 	cmdPrepare.PersistentFlags().StringVar(&tpccConfig.SpecifiedTables, "tables", "", "Specified tables for "+
 		"generating file, separated by ','. Valid only if output is set. If this flag is not set, generate all tables by default")
-	cmdPrepare.PersistentFlags().IntVar(&tpccConfig.PrepareReCommitCount, "retry-count", 50, "Retry count when errors occur")
-	cmdPrepare.PersistentFlags().DurationVar(&tpccConfig.PrepareReCommitDuration, "retry-duration", 10*time.Second, "The duration for each retry")
+	cmdPrepare.PersistentFlags().IntVar(&tpccConfig.PrepareRetryCount, "retry-count", 50, "Retry count when errors occur")
+	cmdPrepare.PersistentFlags().DurationVar(&tpccConfig.PrepareRetryInterval, "retry-interval", 10*time.Second, "The interval for each retry")
 
 	var cmdRun = &cobra.Command{
 		Use:   "run",

--- a/tpcc/load.go
+++ b/tpcc/load.go
@@ -25,7 +25,7 @@ func (w *Workloader) loadItem(ctx context.Context) error {
 	s := getTPCCState(ctx)
 	hint := "INSERT INTO item (i_id, i_im_id, i_name, i_price, i_data) VALUES "
 
-	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareReCommitCount, w.cfg.PrepareReCommitDuration)
+	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareRetryCount, w.cfg.PrepareRetryInterval)
 
 	for i := 0; i < maxItems; i++ {
 		s.Buf.Reset()
@@ -50,7 +50,7 @@ func (w *Workloader) loadWarehouse(ctx context.Context, warehouse int) error {
 	s := getTPCCState(ctx)
 	hint := "INSERT INTO warehouse (w_id, w_name, w_street_1, w_street_2, w_city, w_state, w_zip, w_tax, w_ytd) VALUES "
 
-	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareReCommitCount, w.cfg.PrepareReCommitDuration)
+	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareRetryCount, w.cfg.PrepareRetryInterval)
 
 	wName := randChars(s.R, s.Buf, 6, 10)
 	wStree1 := randChars(s.R, s.Buf, 10, 20)
@@ -80,7 +80,7 @@ func (w *Workloader) loadStock(ctx context.Context, warehouse int) error {
 s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, 
 s_dist_07, s_dist_08, s_dist_09, s_dist_10, s_ytd, s_order_cnt, s_remote_cnt, s_data) VALUES `
 
-	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareReCommitCount, w.cfg.PrepareReCommitDuration)
+	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareRetryCount, w.cfg.PrepareRetryInterval)
 
 	for i := 0; i < stockPerWarehouse; i++ {
 		s.Buf.Reset()
@@ -122,7 +122,7 @@ func (w *Workloader) loadDistrict(ctx context.Context, warehouse int) error {
 	hint := `INSERT INTO district (d_id, d_w_id, d_name, d_street_1, d_street_2, 
 d_city, d_state, d_zip, d_tax, d_ytd, d_next_o_id) VALUES `
 
-	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareReCommitCount, w.cfg.PrepareReCommitDuration)
+	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareRetryCount, w.cfg.PrepareRetryInterval)
 
 	for i := 0; i < districtPerWarehouse; i++ {
 		s.Buf.Reset()
@@ -158,7 +158,7 @@ func (w *Workloader) loadCustomer(ctx context.Context, warehouse int, district i
 c_street_1, c_street_2, c_city, c_state, c_zip, c_phone, c_since, c_credit, c_credit_lim,
 c_discount, c_balance, c_ytd_payment, c_payment_cnt, c_delivery_cnt, c_data) VALUES `
 
-	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareReCommitCount, w.cfg.PrepareReCommitDuration)
+	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareRetryCount, w.cfg.PrepareRetryInterval)
 
 	for i := 0; i < customerPerDistrict; i++ {
 		s.Buf.Reset()
@@ -212,7 +212,7 @@ func (w *Workloader) loadHistory(ctx context.Context, warehouse int, district in
 	s := getTPCCState(ctx)
 
 	hint := `INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_date, h_amount, h_data) VALUES `
-	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareReCommitCount, w.cfg.PrepareReCommitDuration)
+	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareRetryCount, w.cfg.PrepareRetryInterval)
 
 	// 1 customer has 1 row
 	for i := 0; i < customerPerDistrict; i++ {
@@ -245,7 +245,7 @@ func (w *Workloader) loadOrder(ctx context.Context, warehouse int, district int)
 	hint := `INSERT INTO orders (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, 
 o_carrier_id, o_ol_cnt, o_all_local) VALUES `
 
-	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareReCommitCount, w.cfg.PrepareReCommitDuration)
+	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareRetryCount, w.cfg.PrepareRetryInterval)
 
 	cids := rand.Perm(orderPerDistrict)
 	s.R.Shuffle(len(cids), func(i, j int) {
@@ -285,7 +285,7 @@ func (w *Workloader) loadNewOrder(ctx context.Context, warehouse int, district i
 
 	hint := `INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES `
 
-	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareReCommitCount, w.cfg.PrepareReCommitDuration)
+	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareRetryCount, w.cfg.PrepareRetryInterval)
 
 	for i := 0; i < newOrderPerDistrict; i++ {
 		s.Buf.Reset()
@@ -312,7 +312,7 @@ func (w *Workloader) loadOrderLine(ctx context.Context, warehouse int, district 
 	hint := `INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, ol_number,
 ol_i_id, ol_supply_w_id, ol_delivery_d, ol_quantity, ol_amount, ol_dist_info) VALUES `
 
-	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareReCommitCount, w.cfg.PrepareReCommitDuration)
+	l := load.NewSQLBatchLoader(w.db, hint, w.cfg.PrepareRetryCount, w.cfg.PrepareRetryInterval)
 
 	for i := 0; i < orderPerDistrict; i++ {
 		for j := 0; j < olCnts[i]; j++ {

--- a/tpcc/workload.go
+++ b/tpcc/workload.go
@@ -66,8 +66,8 @@ type Config struct {
 	SpecifiedTables string
 
 	// connection, retry count when commiting statement fails, default 0
-	PrepareReCommitCount    int
-	PrepareReCommitDuration time.Duration
+	PrepareRetryCount    int
+	PrepareRetryInterval time.Duration
 }
 
 // Workloader is TPCC workload


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

This PR ignores the non-first `Duplicated entry` error.

```log
load to district in warehouse 672
exec statement error: invalid connection, may try again later...
[mysql] 2021/04/01 07:31:43 packets.go:36: unexpected EOF
...
exec statement error: Error 1062: Duplicate entry '672-1' for key 'PRIMARY', may try again later...
exec statement error: Error 1062: Duplicate entry '780-1' for key 'PRIMARY', may try again later...
load to district in warehouse 1088
load to warehouse in warehouse 1188
load to stock in warehouse 1188
exec statement error: Error 1062: Duplicate entry '672-1' for key 'PRIMARY', may try again later...
exec statement error: Error 1062: Duplicate entry '780-1' for key 'PRIMARY', may try again later...
load to district in warehouse 1006
load to warehouse in warehouse 1106
load to stock in warehouse 1106
panic: a fatal occurred when preparing data: load district at wareshouse 672 failed exec statement error: Error 1062: Duplicate entry '672-1' for key 'PRIMARY'

goroutine 120 [running]:
main.executeWorkload.func2(0xc000279320, 0xc64860, 0xc0002aaae0, 0xc6e800, 0xc0002aaa80, 0xb5633a, 0x7, 0x64, 0x47)
	/home/runner/work/go-tpc/go-tpc/cmd/go-tpc/misc.go:109 +0x2bb
created by main.executeWorkload
	/home/runner/work/go-tpc/go-tpc/cmd/go-tpc/misc.go:105 +0x195
```
