### PR TITLE
Change Current to Timestamp

### DIFF
--- a/pkg/measurement/measure.go
+++ b/pkg/measurement/measure.go
@@ -2,6 +2,7 @@ package measurement
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -85,7 +86,12 @@ func (m *Measurement) Output(ifSummaryReport bool, outputFunc func(string, map[s
 	var opCurMeasurement = m.takeCurMeasurement()
 	m.RLock()
 	defer m.RUnlock()
-	outputFunc("[Current] ", opCurMeasurement)
+	currentTime := time.Now()
+	var sb strings.Builder
+	sb.WriteString("[")
+	sb.WriteString(currentTime.Format("2006-01-02 15:04:05"))
+	sb.WriteString("]")
+	outputFunc(sb.String(), opCurMeasurement)
 }
 
 // EnableWarmUp sets whether to enable warm-up.


### PR DESCRIPTION
Optimizer the output, We need the timestamp to collect detail performance data point.

new output format as below

```
[2021-04-16 16:36:23]DELIVERY - Takes(s): 9.1, Count: 32, TPM: 211.1, Sum(ms): 1759.6, Avg(ms): 54.8, 50th(ms): 52.4, 90th(ms): 67.1, 95th(ms): 75.5, 99th(ms): 92.3, 99.9th(ms): 92.3, Max(ms): 92.3
[2021-04-16 16:36:23]NEW_ORDER - Takes(s): 9.9, Count: 316, TPM: 1907.1, Sum(ms): 4844.6, Avg(ms): 15.3, 50th(ms): 14.7, 90th(ms): 18.9, 95th(ms): 21.0, 99th(ms): 41.9, 99.9th(ms): 58.7, Max(ms): 58.7
[2021-04-16 16:36:23]ORDER_STATUS - Takes(s): 9.5, Count: 31, TPM: 196.3, Sum(ms): 213.3, Avg(ms): 6.8, 50th(ms): 6.8, 90th(ms): 8.9, 95th(ms): 9.4, 99th(ms): 11.0, 99.9th(ms): 11.0, Max(ms): 11.0
[2021-04-16 16:36:23]PAYMENT - Takes(s): 10.0, Count: 293, TPM: 1759.9, Sum(ms): 2720.4, Avg(ms): 9.3, 50th(ms): 8.9, 90th(ms): 12.1, 95th(ms): 13.1, 99th(ms): 16.3, 99.9th(ms): 35.7, Max(ms): 35.7
[2021-04-16 16:36:23]STOCK_LEVEL - Takes(s): 9.8, Count: 24, TPM: 147.4, Sum(ms): 361.0, Avg(ms): 15.1, 50th(ms): 13.6, 90th(ms): 17.8, 95th(ms): 22.0, 99th(ms): 41.9, 99.9th(ms): 41.9, Max(ms): 41.9
[2021-04-16 16:36:33]DELIVERY - Takes(s): 9.6, Count: 22, TPM: 137.5, Sum(ms): 1665.0, Avg(ms): 76.1, 50th(ms): 67.1, 90th(ms): 104.9, 95th(ms): 142.6, 99th(ms): 151.0, 99.9th(ms): 151.0, Max(ms): 151.0
[2021-04-16 16:36:33]NEW_ORDER - Takes(s): 10.0, Count: 261, TPM: 1568.1, Sum(ms): 4884.6, Avg(ms): 18.8, 50th(ms): 16.8, 90th(ms): 23.1, 95th(ms): 31.5, 99th(ms): 65.0, 99.9th(ms): 83.9, Max(ms): 83.9
[2021-04-16 16:36:33]ORDER_STATUS - Takes(s): 10.0, Count: 16, TPM: 96.2, Sum(ms): 142.6, Avg(ms): 9.0, 50th(ms): 8.9, 90th(ms): 10.5, 95th(ms): 13.1, 99th(ms): 13.1, 99.9th(ms): 13.1, Max(ms): 13.1
[2021-04-16 16:36:33]PAYMENT - Takes(s): 10.0, Count: 225, TPM: 1354.1, Sum(ms): 2715.2, Avg(ms): 12.1, 50th(ms): 11.0, 90th(ms): 15.2, 95th(ms): 18.9, 99th(ms): 48.2, 99.9th(ms): 79.7, Max(ms): 79.7
[2021-04-16 16:36:33]STOCK_LEVEL - Takes(s): 9.8, Count: 31, TPM: 190.7, Sum(ms): 464.1, Avg(ms): 14.9, 50th(ms): 14.7, 90th(ms): 18.9, 95th(ms): 18.9, 99th(ms): 26.2, 99.9th(ms): 26.2, Max(ms): 26.2

```