### PR TITLE
Update readme: add the `-T` flag on the `prepare` and `run` guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,17 @@ For example:
 #### Prepare
 
 ```bash
-# Create 4 warehouses and use 4 partitions by HASH 
-./bin/go-tpc tpcc --warehouses 4 --parts 4 prepare
+# Create 4 warehouses with 4 threads
+./bin/go-tpc tpcc --warehouses 4 prepare -T 4
 ```
 
 #### Run
 
 ```bash
 # Run TPCC workloads, you can just run or add --wait option to including wait times
-./bin/go-tpc tpcc --warehouses 4 run
+./bin/go-tpc tpcc --warehouses 4 run -T 4
 # Run TPCC including wait times(keying & thinking time) on every transactions
-./bin/go-tpc tpcc --warehouses 4 run --wait
+./bin/go-tpc tpcc --warehouses 4 run -T 4 --wait
 ```
 
 #### Check

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Go TPC
 
-A toolbox to benchmark workloads in [TPC](http://www.tpc.org/)
+A toolbox to benchmark workloads in [TPC](http://www.tpc.org/) for TiDB and almost MySQL compatible databases.
 
 ## Install
+
 You can use one of the three approaches
 
 ### Install using script(recommend)
+
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/pingcap/go-tpc/master/install.sh | sh
 ```
@@ -26,6 +28,7 @@ make build
 Then you can find the `go-tpc` binary file in the `./bin` directory.
 
 ## Usage
+
 If you have `go-tpc` in your PATH, the command below you should replace `./bin/go-tpc` with `go-tpc`
 
 By default, go-tpc uses `root::@tcp(127.0.0.1:4000)/test` as the default dsn address, you can override it by setting below flags:
@@ -43,7 +46,7 @@ By default, go-tpc uses `root::@tcp(127.0.0.1:4000)/test` as the default dsn add
 >
 > When exporting csv files to a directory, `go-tpc` will also create the necessary tables for further data input if 
 > the provided database address is accessible.
-    
+
 For example:
 
 ```bash
@@ -78,7 +81,7 @@ For example:
 #### Clean up
 
 ```bash
-# Cleanup 
+# Cleanup
 ./bin/go-tpc tpcc --warehouses 4 cleanup
 ```
 


### PR DESCRIPTION
 Signed-off-by: mahjonp <junpeng.man@gmail.com>

Users may wonder whether the go-tpc support prepares data with multiple threads and how to do it. I think we'd better add the 'threads' flag on the readme so that users could directly know it's ok for go-tpc.