### PR TITLE
tpcc: Add list and range partitioned table options

### DIFF
--- a/cmd/go-tpc/tpcc.go
+++ b/cmd/go-tpc/tpcc.go
@@ -76,6 +76,7 @@ func registerTpcc(root *cobra.Command) {
 	}
 
 	cmd.PersistentFlags().IntVar(&tpccConfig.Parts, "parts", 1, "Number to partition warehouses")
+	cmd.PersistentFlags().IntVar(&tpccConfig.PartitionType, "partition-type", 1, "Partition type (1 - HASH, 2 - RANGE, 3 - LIST (like HASH), 4 - LIST (like RANGE)")
 	cmd.PersistentFlags().IntVar(&tpccConfig.Warehouses, "warehouses", 10, "Number of warehouses")
 	cmd.PersistentFlags().BoolVar(&tpccConfig.CheckAll, "check-all", false, "Run all consistency checks")
 	var cmdPrepare = &cobra.Command{

--- a/tpcc/csv.go
+++ b/tpcc/csv.go
@@ -42,7 +42,7 @@ func NewCSVWorkloader(db *sql.DB, cfg *Config) (*CSVWorkLoader, error) {
 		cfg:          cfg,
 		initLoadTime: time.Now().Format(timeFormat),
 		tables:       make(map[string]bool),
-		ddlManager:   newDDLManager(cfg.Parts, cfg.UseFK),
+		ddlManager:   newDDLManager(cfg.Parts, cfg.UseFK, cfg.Warehouses, cfg.PartitionType),
 	}
 
 	var val bool

--- a/tpcc/ddl_test.go
+++ b/tpcc/ddl_test.go
@@ -3,7 +3,7 @@ package tpcc
 import "testing"
 
 func TestAppendPartition(t *testing.T) {
-	ddl := newDDLManager(4, false, 4, 1)
+	ddl := newDDLManager(4, false, 4, PartitionTypeHash)
 	s := ddl.appendPartition("<table definition>", "Id")
 	expected := `<table definition>
 PARTITION BY HASH(Id)
@@ -12,7 +12,7 @@ PARTITIONS 4`
 		t.Errorf("got '%s' expected '%s'", s, expected)
 	}
 
-	ddl = newDDLManager(4, false, 4, 2)
+	ddl = newDDLManager(4, false, 4, PartitionTypeRange)
 	s = ddl.appendPartition("<table definition>", "Id")
 	expected = `<table definition>
 PARTITION BY RANGE (Id)
@@ -24,7 +24,7 @@ PARTITION BY RANGE (Id)
 		t.Errorf("got '%s' expected '%s'", s, expected)
 	}
 
-	ddl = newDDLManager(4, false, 23, 2)
+	ddl = newDDLManager(4, false, 23, PartitionTypeRange)
 	s = ddl.appendPartition("<table definition>", "Id")
 	expected = `<table definition>
 PARTITION BY RANGE (Id)
@@ -36,7 +36,7 @@ PARTITION BY RANGE (Id)
 		t.Errorf("got '%s' expected '%s'", s, expected)
 	}
 
-	ddl = newDDLManager(4, false, 12, 3)
+	ddl = newDDLManager(4, false, 12, PartitionTypeListAsHash)
 	s = ddl.appendPartition("<table definition>", "Id")
 	expected = `<table definition>
 PARTITION BY LIST (Id)
@@ -48,7 +48,18 @@ PARTITION BY LIST (Id)
 		t.Errorf("got '%s' expected '%s'", s, expected)
 	}
 
-	ddl = newDDLManager(4, false, 23, 3)
+	ddl = newDDLManager(3, false, 4, PartitionTypeListAsHash)
+	s = ddl.appendPartition("<table definition>", "Id")
+	expected = `<table definition>
+PARTITION BY LIST (Id)
+(PARTITION p0 VALUES IN (1,4),
+ PARTITION p1 VALUES IN (2),
+ PARTITION p2 VALUES IN (3))`
+	if s != expected {
+		t.Errorf("got '%s' expected '%s'", s, expected)
+	}
+
+	ddl = newDDLManager(4, false, 23, PartitionTypeListAsHash)
 	s = ddl.appendPartition("<table definition>", "Id")
 	expected = `<table definition>
 PARTITION BY LIST (Id)
@@ -60,7 +71,7 @@ PARTITION BY LIST (Id)
 		t.Errorf("got '%s' expected '%s'", s, expected)
 	}
 
-	ddl = newDDLManager(4, false, 12, 4)
+	ddl = newDDLManager(4, false, 12, PartitionTypeListAsRange)
 	s = ddl.appendPartition("<table definition>", "Id")
 	expected = `<table definition>
 PARTITION BY LIST (Id)
@@ -72,7 +83,18 @@ PARTITION BY LIST (Id)
 		t.Errorf("got '%s' expected '%s'", s, expected)
 	}
 
-	ddl = newDDLManager(4, false, 23, 4)
+	ddl = newDDLManager(3, false, 4, PartitionTypeListAsRange)
+	s = ddl.appendPartition("<table definition>", "Id")
+	expected = `<table definition>
+PARTITION BY LIST (Id)
+(PARTITION p0 VALUES IN (1,2),
+ PARTITION p1 VALUES IN (3),
+ PARTITION p2 VALUES IN (4))`
+	if s != expected {
+		t.Errorf("got '%s' expected '%s'", s, expected)
+	}
+
+	ddl = newDDLManager(4, false, 23, PartitionTypeListAsRange)
 	s = ddl.appendPartition("<table definition>", "Id")
 	expected = `<table definition>
 PARTITION BY LIST (Id)

--- a/tpcc/ddl_test.go
+++ b/tpcc/ddl_test.go
@@ -1,0 +1,86 @@
+package tpcc
+
+import "testing"
+
+func TestAppendPartition(t *testing.T) {
+	ddl := newDDLManager(4, false, 4, 1)
+	s := ddl.appendPartition("<table definition>", "Id")
+	expected := `<table definition>
+PARTITION BY HASH(Id)
+PARTITIONS 4`
+	if s != expected {
+		t.Errorf("got '%s' expected '%s'", s, expected)
+	}
+
+	ddl = newDDLManager(4, false, 4, 2)
+	s = ddl.appendPartition("<table definition>", "Id")
+	expected = `<table definition>
+PARTITION BY RANGE (Id)
+(PARTITION p0 VALUES LESS THAN (2),
+ PARTITION p1 VALUES LESS THAN (3),
+ PARTITION p2 VALUES LESS THAN (4),
+ PARTITION p3 VALUES LESS THAN (5))`
+	if s != expected {
+		t.Errorf("got '%s' expected '%s'", s, expected)
+	}
+
+	ddl = newDDLManager(4, false, 23, 2)
+	s = ddl.appendPartition("<table definition>", "Id")
+	expected = `<table definition>
+PARTITION BY RANGE (Id)
+(PARTITION p0 VALUES LESS THAN (7),
+ PARTITION p1 VALUES LESS THAN (13),
+ PARTITION p2 VALUES LESS THAN (19),
+ PARTITION p3 VALUES LESS THAN (25))`
+	if s != expected {
+		t.Errorf("got '%s' expected '%s'", s, expected)
+	}
+
+	ddl = newDDLManager(4, false, 12, 3)
+	s = ddl.appendPartition("<table definition>", "Id")
+	expected = `<table definition>
+PARTITION BY LIST (Id)
+(PARTITION p0 VALUES IN (1,5,9),
+ PARTITION p1 VALUES IN (2,6,10),
+ PARTITION p2 VALUES IN (3,7,11),
+ PARTITION p3 VALUES IN (4,8,12))`
+	if s != expected {
+		t.Errorf("got '%s' expected '%s'", s, expected)
+	}
+
+	ddl = newDDLManager(4, false, 23, 3)
+	s = ddl.appendPartition("<table definition>", "Id")
+	expected = `<table definition>
+PARTITION BY LIST (Id)
+(PARTITION p0 VALUES IN (1,5,9,13,17,21),
+ PARTITION p1 VALUES IN (2,6,10,14,18,22),
+ PARTITION p2 VALUES IN (3,7,11,15,19,23),
+ PARTITION p3 VALUES IN (4,8,12,16,20))`
+	if s != expected {
+		t.Errorf("got '%s' expected '%s'", s, expected)
+	}
+
+	ddl = newDDLManager(4, false, 12, 4)
+	s = ddl.appendPartition("<table definition>", "Id")
+	expected = `<table definition>
+PARTITION BY LIST (Id)
+(PARTITION p0 VALUES IN (1,2,3),
+ PARTITION p1 VALUES IN (4,5,6),
+ PARTITION p2 VALUES IN (7,8,9),
+ PARTITION p3 VALUES IN (10,11,12))`
+	if s != expected {
+		t.Errorf("got '%s' expected '%s'", s, expected)
+	}
+
+	ddl = newDDLManager(4, false, 23, 4)
+	s = ddl.appendPartition("<table definition>", "Id")
+	expected = `<table definition>
+PARTITION BY LIST (Id)
+(PARTITION p0 VALUES IN (1,2,3,4,5,6),
+ PARTITION p1 VALUES IN (7,8,9,10,11,12),
+ PARTITION p2 VALUES IN (13,14,15,16,17,18),
+ PARTITION p3 VALUES IN (19,20,21,22,23))`
+	if s != expected {
+		t.Errorf("got '%s' expected '%s'", s, expected)
+	}
+}


### PR DESCRIPTION
The tpcc test is a good match for partitioned tables, since the tables have a natural composite primary key including 'warehouse id'. This makes it good to test the different int based partitioning schemes like HASH, LIST and RANGE partitioned tables.

Currently only HASH was supported, this adds RANGE as well as two distributions of LIST partitioning (LIST partitioning, like it HASH or RANGE)