### PR TITLE
rawsql: introduce rawsql command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ By default, go-tpc uses `root::@tcp(127.0.0.1:4000)/test` as the default dsn add
 
 > **Note:**
 >
-> When exporting csv files to a directory, `go-tpc` will also create the necessary tables for further data input if 
+> When exporting csv files to a directory, `go-tpc` will also create the necessary tables for further data input if
 > the provided database address is accessible.
 
 For example:
@@ -144,4 +144,12 @@ If you want to import tpcc data into TiDB, please refer to [import-to-tidb](docs
 
 ```bash
 ./bin/go-tpc ch --warehouses $warehouses -T $tpWorkers -t $apWorkers --time $measurement-time run
+```
+
+### Raw SQL
+`rawsql` command is used to execute sql from given sql files.
+
+#### Run
+```bash
+./bin/go-tpc rawsql run --query-files $path-to-query-files
 ```

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -108,8 +108,8 @@ func main() {
 	rootCmd.PersistentFlags().BoolVar(&ignoreError, "ignore-error", false, "Ignore error when running workload")
 	rootCmd.PersistentFlags().BoolVar(&silence, "silence", false, "Don't print error when running workload")
 	rootCmd.PersistentFlags().DurationVar(&outputInterval, "interval", 10*time.Second, "Output interval time")
-	rootCmd.PersistentFlags().IntVar(&isolationLevel, "isolation", 0, `Isolation Level 0: Default, 1: ReadUncommitted, 
-2: ReadCommitted, 3: WriteCommitted, 4: RepeatableRead, 
+	rootCmd.PersistentFlags().IntVar(&isolationLevel, "isolation", 0, `Isolation Level 0: Default, 1: ReadUncommitted,
+2: ReadCommitted, 3: WriteCommitted, 4: RepeatableRead,
 5: Snapshot, 6: Serializable, 7: Linerizable`)
 	rootCmd.PersistentFlags().StringVar(&connParams, "conn-params", "", "session variables")
 
@@ -119,6 +119,7 @@ func main() {
 	registerTpcc(rootCmd)
 	registerTpch(rootCmd)
 	registerCHBenchmark(rootCmd)
+	registerRawsql(rootCmd)
 
 	var cancel context.CancelFunc
 	globalCtx, cancel = context.WithCancel(context.Background())

--- a/cmd/go-tpc/rawsql.go
+++ b/cmd/go-tpc/rawsql.go
@@ -60,7 +60,7 @@ func execRawsql(action string) {
 	rawsqlConfig.QueryNames = strings.Split(queryFiles, ",")
 	rawsqlConfig.Queries = make(map[string]string, len(rawsqlConfig.QueryNames))
 
-	for _, filename := range rawsqlConfig.QueryNames {
+	for i, filename := range rawsqlConfig.QueryNames {
 		queryData, err := ioutil.ReadFile(filename)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "read file: %s, err: %v\n", filename, err)
@@ -69,6 +69,7 @@ func execRawsql(action string) {
 
 		baseName := path.Base(filename)
 		queryName := strings.TrimSuffix(baseName, path.Ext(baseName))
+		rawsqlConfig.QueryNames[i] = queryName
 		rawsqlConfig.Queries[queryName] = string(queryData)
 	}
 

--- a/cmd/go-tpc/rawsql.go
+++ b/cmd/go-tpc/rawsql.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/pingcap/go-tpc/rawsql"
@@ -66,7 +67,9 @@ func execRawsql(action string) {
 			os.Exit(1)
 		}
 
-		rawsqlConfig.Queries[filename] = string(queryData)
+		baseName := path.Base(filename)
+		queryName := strings.TrimSuffix(baseName, path.Ext(baseName))
+		rawsqlConfig.Queries[queryName] = string(queryData)
 	}
 
 	w := rawsql.NewWorkloader(globalDB, &rawsqlConfig)

--- a/cmd/go-tpc/rawsql.go
+++ b/cmd/go-tpc/rawsql.go
@@ -7,13 +7,17 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/pingcap/go-tpc/rawsql"
 	"github.com/spf13/cobra"
 )
 
-var rawsqlConfig rawsql.Config
-var queryFiles string
+var (
+	rawsqlConfig    rawsql.Config
+	queryFiles      string
+	refreshConnWait time.Duration
+)
 
 func registerRawsql(root *cobra.Command) {
 	cmd := &cobra.Command{
@@ -42,6 +46,8 @@ func registerRawsql(root *cobra.Command) {
 		false,
 		"execute explain analyze")
 
+	cmdRun.PersistentFlags().DurationVar(&refreshConnWait, "refresh-conn-wait", 5*time.Second, "duration to wait before refreshing sql connection")
+
 	cmd.AddCommand(cmdRun)
 	root.AddCommand(cmd)
 }
@@ -59,6 +65,7 @@ func execRawsql(action string) {
 	rawsqlConfig.DBName = dbName
 	rawsqlConfig.QueryNames = strings.Split(queryFiles, ",")
 	rawsqlConfig.Queries = make(map[string]string, len(rawsqlConfig.QueryNames))
+	rawsqlConfig.RefreshWait = refreshConnWait
 
 	for i, filename := range rawsqlConfig.QueryNames {
 		queryData, err := ioutil.ReadFile(filename)

--- a/cmd/go-tpc/rawsql.go
+++ b/cmd/go-tpc/rawsql.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/pingcap/go-tpc/rawsql"
+	"github.com/spf13/cobra"
+)
+
+var rawsqlConfig rawsql.Config
+var queryFiles string
+
+func registerRawsql(root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use: "rawsql",
+	}
+
+	cmdRun := &cobra.Command{
+		Use:   "run",
+		Short: "Run workload",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(queryFiles) == 0 {
+				fmt.Fprintln(os.Stderr, "empty query files")
+				os.Exit(1)
+			}
+
+			execRawsql("run")
+		},
+	}
+	cmdRun.PersistentFlags().StringVar(&queryFiles,
+		"query-files",
+		"",
+		"path of query files")
+
+	cmdRun.PersistentFlags().BoolVar(&rawsqlConfig.ExecExplainAnalyze,
+		"use-explain",
+		false,
+		"execute explain analyze")
+
+	cmd.AddCommand(cmdRun)
+	root.AddCommand(cmd)
+}
+
+func execRawsql(action string) {
+	openDB()
+	defer closeDB()
+
+	// if globalDB == nil
+	if globalDB == nil {
+		fmt.Fprintln(os.Stderr, "cannot connect to the database")
+		os.Exit(1)
+	}
+
+	rawsqlConfig.DBName = dbName
+	rawsqlConfig.QueryNames = strings.Split(queryFiles, ",")
+	rawsqlConfig.Queries = make(map[string]string, len(rawsqlConfig.QueryNames))
+
+	for _, filename := range rawsqlConfig.QueryNames {
+		queryData, err := ioutil.ReadFile(filename)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "read file: %s, err: %v\n", filename, err)
+			os.Exit(1)
+		}
+
+		rawsqlConfig.Queries[filename] = string(queryData)
+	}
+
+	w := rawsql.NewWorkloader(globalDB, &rawsqlConfig)
+
+	timeoutCtx, cancel := context.WithTimeout(globalCtx, totalTime)
+	defer cancel()
+	executeWorkload(timeoutCtx, w, threads, action)
+	fmt.Println("Finished")
+	w.OutputStats(true)
+}

--- a/rawsql/workload.go
+++ b/rawsql/workload.go
@@ -1,0 +1,138 @@
+package rawsql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/pingcap/go-tpc/pkg/measurement"
+	"github.com/pingcap/go-tpc/pkg/workload"
+)
+
+type contextKey string
+
+const stateKey = contextKey("rawsql")
+
+type Config struct {
+	DBName             string
+	Queries            map[string]string // query name: query SQL
+	QueryNames         []string
+	ExecExplainAnalyze bool
+}
+
+type rawsqlState struct {
+	queryIdx int
+	*workload.TpcState
+}
+
+type Workloader struct {
+	cfg *Config
+	db  *sql.DB
+
+	measurement *measurement.Measurement
+}
+
+var _ workload.Workloader = &Workloader{}
+
+func NewWorkloader(db *sql.DB, cfg *Config) workload.Workloader {
+	return &Workloader{
+		db:  db,
+		cfg: cfg,
+		measurement: measurement.NewMeasurement(func(m *measurement.Measurement) {
+			m.MinLatency = 100 * time.Microsecond
+			m.MaxLatency = 20 * time.Minute
+			m.SigFigs = 3
+		}),
+	}
+}
+
+func (w *Workloader) Name() string {
+	return "rawsql"
+}
+
+func (w *Workloader) InitThread(ctx context.Context, threadID int) context.Context {
+	s := &rawsqlState{
+		queryIdx: threadID,
+		TpcState: workload.NewTpcState(ctx, w.db),
+	}
+
+	ctx = context.WithValue(ctx, stateKey, s)
+	return ctx
+}
+
+func (w *Workloader) getState(ctx context.Context) *rawsqlState {
+	s := ctx.Value(stateKey).(*rawsqlState)
+	return s
+}
+
+func (w *Workloader) updateState(ctx context.Context) {
+	s := w.getState(ctx)
+	s.queryIdx++
+}
+
+func (w *Workloader) CleanupThread(ctx context.Context, threadID int) {
+	s := w.getState(ctx)
+	s.Conn.Close()
+}
+
+func (w *Workloader) Run(ctx context.Context, threadID int) error {
+	s := w.getState(ctx)
+	defer w.updateState(ctx)
+
+	queryName := w.cfg.QueryNames[s.queryIdx%len(w.cfg.QueryNames)]
+	query := w.cfg.Queries[queryName]
+
+	start := time.Now()
+	rows, err := s.Conn.QueryContext(ctx, query)
+	w.measurement.Measure(queryName, time.Since(start), err)
+	if err != nil {
+		return fmt.Errorf("execute query %s failed %v", queryName, err)
+	}
+	defer rows.Close()
+	return nil
+}
+
+func outputMeasurement(prefix string, opMeasurement map[string]*measurement.Histogram) {
+	keys := make([]string, len(opMeasurement))
+	var i = 0
+	for k := range opMeasurement {
+		keys[i] = k
+		i += 1
+	}
+	sort.Strings(keys)
+
+	for _, op := range keys {
+		hist := opMeasurement[op]
+		if !hist.Empty() {
+			fmt.Printf("%s%s: %.2fs\n", prefix, strings.ToUpper(op), float64(hist.GetInfo().Avg)/1000)
+		}
+	}
+}
+
+func (w *Workloader) OutputStats(ifSummaryReport bool) {
+	w.measurement.Output(ifSummaryReport, outputMeasurement)
+}
+
+func (w *Workloader) DBName() string {
+	return w.cfg.DBName
+}
+
+func (w *Workloader) Prepare(ctx context.Context, threadID int) error {
+	// how to prepare data is undecided
+	panic("not implemented") // TODO: Implement
+}
+
+func (w *Workloader) CheckPrepare(ctx context.Context, threadID int) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (w *Workloader) Cleanup(ctx context.Context, threadID int) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (w *Workloader) Check(ctx context.Context, threadID int) error {
+	panic("not implemented") // TODO: Implement
+}


### PR DESCRIPTION
enables go-tpc to run custom sql queries.

usage: `./bin/go-tpc rawsql run --query-files $path-to-query-files`