### PR TITLE
Added tpcc weights for ch-benchmark

### DIFF
--- a/cmd/go-tpc/ch_benchmark.go
+++ b/cmd/go-tpc/ch_benchmark.go
@@ -68,6 +68,7 @@ func registerCHBenchmark(root *cobra.Command) {
 			executeCH("run")
 		},
 	}
+	cmdRun.PersistentFlags().IntSliceVar(&tpccConfig.Weight, "weight", []int{45, 43, 4, 4, 4}, "Weight for NewOrder, Payment, OrderStatus, Delivery, StockLevel")
 	cmd.AddCommand(cmdRun, cmdPrepare)
 	root.AddCommand(cmd)
 }


### PR DESCRIPTION
It hasn't been possible to change the transactional workload when running `go-tpc ch run`.

This PR fixes that by adding a weight flag to `go-tpc ch run` in the same manner as the tpcc benchmark.