### PR TITLE
support plan replayer for tpch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 dist/
 .vscode/
 .DS_Store
+vendor/

--- a/ch/workload.go
+++ b/ch/workload.go
@@ -264,3 +264,15 @@ func (w Workloader) OutputStats(ifSummaryReport bool) {
 func (w Workloader) DBName() string {
 	return w.cfg.DBName
 }
+
+func (w Workloader) IsPlanReplayerDumpEnabled() bool {
+	return false
+}
+
+func (w Workloader) PreparePlanReplayerDump() error {
+	return nil
+}
+
+func (w Workloader) FinishPlanReplayerDump() error {
+	return nil
+}

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -20,6 +20,7 @@ var (
 	dbName         string
 	host           string
 	port           int
+	statusPort     int
 	user           string
 	password       string
 	threads        int
@@ -100,6 +101,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVarP(&user, "user", "U", "root", "Database user")
 	rootCmd.PersistentFlags().StringVarP(&password, "password", "p", "", "Database password")
 	rootCmd.PersistentFlags().IntVarP(&port, "port", "P", 4000, "Database port")
+	rootCmd.PersistentFlags().IntVarP(&statusPort, "statusPort", "S", 10080, "Database status port")
 	rootCmd.PersistentFlags().IntVarP(&threads, "threads", "T", 1, "Thread concurrency")
 	rootCmd.PersistentFlags().IntVarP(&acThreads, "acThreads", "t", 1, "OLAP client concurrency, only for CH-benCHmark")
 	rootCmd.PersistentFlags().StringVarP(&driver, "driver", "d", "", "Database driver: mysql")

--- a/cmd/go-tpc/misc.go
+++ b/cmd/go-tpc/misc.go
@@ -58,6 +58,21 @@ func execute(ctx context.Context, w workload.Workloader, action string, threads,
 		return w.Check(ctx, index)
 	}
 
+	enabledDumpPlanReplayer := w.IsPlanReplayerDumpEnabled()
+	if enabledDumpPlanReplayer {
+		err := w.PreparePlanReplayerDump()
+		if err != nil {
+			return err
+		}
+		defer func() {
+			err := w.FinishPlanReplayerDump()
+			if err != nil {
+				fmt.Printf("[%s] dump plan replayer failed, err%v\n",
+					time.Now().Format("2006-01-02 15:04:05"), err)
+			}
+		}()
+	}
+
 	for i := 0; i < count || count <= 0; i++ {
 		err := w.Run(ctx, index)
 

--- a/cmd/go-tpc/tpch.go
+++ b/cmd/go-tpc/tpch.go
@@ -6,9 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/cobra"
-
 	"github.com/pingcap/go-tpc/tpch"
+	"github.com/spf13/cobra"
 )
 
 var tpchConfig tpch.Config
@@ -22,11 +21,12 @@ func executeTpch(action string) {
 		os.Exit(1)
 	}
 
+	tpchConfig.Host = host
+	tpchConfig.StatusPort = statusPort
 	tpchConfig.DBName = dbName
 	tpchConfig.PrepareThreads = threads
 	tpchConfig.QueryNames = strings.Split(tpchConfig.RawQueries, ",")
 	w := tpch.NewWorkloader(globalDB, &tpchConfig)
-
 	timeoutCtx, cancel := context.WithTimeout(globalCtx, totalTime)
 	defer cancel()
 
@@ -59,6 +59,21 @@ func registerTpch(root *cobra.Command) {
 		"check",
 		false,
 		"Check output data, only when the scale factor equals 1")
+
+	cmd.PersistentFlags().BoolVar(&tpchConfig.EnablePlanReplayer,
+		"use-plan-replayer",
+		false,
+		"Use Plan Replayer to dump stats and variables before running queries")
+
+	cmd.PersistentFlags().StringVar(&tpchConfig.PlanReplayerDir,
+		"plan-replayer-dir",
+		"",
+		"Dir of Plan Replayer file dumps")
+
+	cmd.PersistentFlags().StringVar(&tpchConfig.PlanReplayerFileName,
+		"plan-replayer-file",
+		"",
+		"Name of plan Replayer file dumps")
 
 	var cmdPrepare = &cobra.Command{
 		Use:   "prepare",

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -16,4 +16,8 @@ type Workloader interface {
 	Check(ctx context.Context, threadID int) error
 	OutputStats(ifSummaryReport bool)
 	DBName() string
+
+	IsPlanReplayerDumpEnabled() bool
+	PreparePlanReplayerDump() error
+	FinishPlanReplayerDump() error
 }

--- a/rawsql/workload.go
+++ b/rawsql/workload.go
@@ -158,3 +158,15 @@ func (w *Workloader) Cleanup(ctx context.Context, threadID int) error {
 func (w *Workloader) Check(ctx context.Context, threadID int) error {
 	panic("not implemented") // TODO: Implement
 }
+
+func (w Workloader) IsPlanReplayerDumpEnabled() bool {
+	return false
+}
+
+func (w Workloader) PreparePlanReplayerDump() error {
+	return nil
+}
+
+func (w Workloader) FinishPlanReplayerDump() error {
+	return nil
+}

--- a/tpcc/csv.go
+++ b/tpcc/csv.go
@@ -487,3 +487,15 @@ func (c *CSVWorkLoader) loadOrderLine(ctx context.Context, warehouse int,
 
 	return l.Flush(ctx)
 }
+
+func (c *CSVWorkLoader) IsPlanReplayerDumpEnabled() bool {
+	return false
+}
+
+func (c *CSVWorkLoader) PreparePlanReplayerDump() error {
+	return nil
+}
+
+func (c *CSVWorkLoader) FinishPlanReplayerDump() error {
+	return nil
+}

--- a/tpcc/workload.go
+++ b/tpcc/workload.go
@@ -434,3 +434,15 @@ func closeStmts(stmts map[string]*sql.Stmt) {
 		stmt.Close()
 	}
 }
+
+func (w *Workloader) IsPlanReplayerDumpEnabled() bool {
+	return false
+}
+
+func (w *Workloader) PreparePlanReplayerDump() error {
+	return nil
+}
+
+func (w *Workloader) FinishPlanReplayerDump() error {
+	return nil
+}

--- a/tpch/check.go
+++ b/tpch/check.go
@@ -51,7 +51,7 @@ var queryColPrecisions = map[string][]precision{
 	"q22": {num, cnt, sum},
 }
 
-func (w Workloader) scanQueryResult(queryName string, rows *sql.Rows) error {
+func (w *Workloader) scanQueryResult(queryName string, rows *sql.Rows) error {
 	var got [][]string
 
 	cols, err := rows.Columns()

--- a/tpch/ddl.go
+++ b/tpch/ddl.go
@@ -28,7 +28,7 @@ func (w *Workloader) createTableDDL(ctx context.Context, query string, tableName
 }
 
 // createTables creates tables schema.
-func (w Workloader) createTables(ctx context.Context) error {
+func (w *Workloader) createTables(ctx context.Context) error {
 	query := `
 CREATE TABLE IF NOT EXISTS nation (
     N_NATIONKEY BIGINT NOT NULL,

--- a/tpch/workload.go
+++ b/tpch/workload.go
@@ -281,7 +281,7 @@ func outputRtMeasurement(outputStyle string, prefix string, opMeasurement map[st
 	}
 }
 
-func (w Workloader) OutputStats(ifSummaryReport bool) {
+func (w *Workloader) OutputStats(ifSummaryReport bool) {
 	w.measurement.Output(ifSummaryReport, w.cfg.OutputStyle, outputRtMeasurement)
 }
 

--- a/tpch/workload.go
+++ b/tpch/workload.go
@@ -1,13 +1,20 @@
 package tpch
 
 import (
+	"archive/zip"
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pingcap/go-tpc/pkg/measurement"
@@ -39,6 +46,12 @@ type Config struct {
 	AnalyzeTable         analyzeConfig
 	ExecExplainAnalyze   bool
 	PrepareThreads       int
+	Host                 string
+	StatusPort           int
+
+	EnablePlanReplayer   bool
+	PlanReplayerDir      string
+	PlanReplayerFileName string
 
 	// for prepare command only
 	OutputType string
@@ -57,11 +70,17 @@ type Workloader struct {
 
 	// stats
 	measurement *measurement.Measurement
+
+	zf *os.File
+	zw struct {
+		sync.Mutex
+		writer *zip.Writer
+	}
 }
 
 // NewWorkloader new work loader
 func NewWorkloader(db *sql.DB, cfg *Config) workload.Workloader {
-	return Workloader{
+	return &Workloader{
 		db:  db,
 		cfg: cfg,
 		measurement: measurement.NewMeasurement(func(m *measurement.Measurement) {
@@ -83,12 +102,12 @@ func (w *Workloader) updateState(ctx context.Context) {
 }
 
 // Name return workloader name
-func (w Workloader) Name() string {
+func (w *Workloader) Name() string {
 	return "tpch"
 }
 
 // InitThread inits thread
-func (w Workloader) InitThread(ctx context.Context, threadID int) context.Context {
+func (w *Workloader) InitThread(ctx context.Context, threadID int) context.Context {
 	s := &tpchState{
 		queryIdx: threadID % len(w.cfg.QueryNames),
 		TpcState: workload.NewTpcState(ctx, w.db),
@@ -99,13 +118,13 @@ func (w Workloader) InitThread(ctx context.Context, threadID int) context.Contex
 }
 
 // CleanupThread cleans up thread
-func (w Workloader) CleanupThread(ctx context.Context, threadID int) {
+func (w *Workloader) CleanupThread(ctx context.Context, threadID int) {
 	s := w.getState(ctx)
 	s.Conn.Close()
 }
 
 // Prepare prepares data
-func (w Workloader) Prepare(ctx context.Context, threadID int) error {
+func (w *Workloader) Prepare(ctx context.Context, threadID int) error {
 	if threadID != 0 {
 		return nil
 	}
@@ -160,7 +179,7 @@ func (w Workloader) Prepare(ctx context.Context, threadID int) error {
 	return nil
 }
 
-func (w Workloader) analyzeTables(ctx context.Context, acfg analyzeConfig) error {
+func (w *Workloader) analyzeTables(ctx context.Context, acfg analyzeConfig) error {
 	s := w.getState(ctx)
 	for _, tbl := range allTables {
 		fmt.Printf("analyzing table %s\n", tbl)
@@ -173,17 +192,24 @@ func (w Workloader) analyzeTables(ctx context.Context, acfg analyzeConfig) error
 }
 
 // CheckPrepare checks prepare
-func (w Workloader) CheckPrepare(ctx context.Context, threadID int) error {
+func (w *Workloader) CheckPrepare(ctx context.Context, threadID int) error {
 	return nil
 }
 
 // Run runs workload
-func (w Workloader) Run(ctx context.Context, threadID int) error {
+func (w *Workloader) Run(ctx context.Context, threadID int) error {
 	s := w.getState(ctx)
 	defer w.updateState(ctx)
 
 	queryName := w.cfg.QueryNames[s.queryIdx%len(w.cfg.QueryNames)]
 	query := queries[queryName]
+	if w.cfg.EnablePlanReplayer {
+		err := w.dumpPlanReplayer(ctx, s, query, queryName)
+		if err != nil {
+			return err
+		}
+	}
+
 	if w.cfg.ExecExplainAnalyze {
 		query = strings.Replace(query, "/*PLACEHOLDER*/", "explain analyze", 1)
 	}
@@ -214,7 +240,7 @@ func (w Workloader) Run(ctx context.Context, threadID int) error {
 }
 
 // Cleanup cleans up workloader
-func (w Workloader) Cleanup(ctx context.Context, threadID int) error {
+func (w *Workloader) Cleanup(ctx context.Context, threadID int) error {
 	if threadID != 0 {
 		return nil
 	}
@@ -222,7 +248,7 @@ func (w Workloader) Cleanup(ctx context.Context, threadID int) error {
 }
 
 // Check checks data
-func (w Workloader) Check(ctx context.Context, threadID int) error {
+func (w *Workloader) Check(ctx context.Context, threadID int) error {
 	return nil
 }
 
@@ -243,11 +269,110 @@ func outputRtMeasurement(prefix string, opMeasurement map[string]*measurement.Hi
 	}
 }
 
-func (w Workloader) OutputStats(ifSummaryReport bool) {
+func (w *Workloader) OutputStats(ifSummaryReport bool) {
 	w.measurement.Output(ifSummaryReport, outputRtMeasurement)
 }
 
 // DBName returns the name of test db.
-func (w Workloader) DBName() string {
+func (w *Workloader) DBName() string {
 	return w.cfg.DBName
+}
+
+func (w *Workloader) dumpPlanReplayer(ctx context.Context, s *tpchState, query, queryName string) error {
+	query = strings.Replace(query, "/*PLACEHOLDER*/", "plan replayer dump explain", 1)
+	rows, err := s.Conn.QueryContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("execute query %s failed %v", query, err)
+	}
+	defer rows.Close()
+	var token string
+	for rows.Next() {
+		err := rows.Scan(&token)
+		if err != nil {
+			return fmt.Errorf("execute query %s failed %v", query, err)
+		}
+	}
+	// TODO: support tls
+	r, err := http.Get(fmt.Sprintf("http://%s:%v/plan_replayer/dump/%s", w.cfg.Host, w.cfg.StatusPort, token))
+	if err != nil {
+		return fmt.Errorf("get plan replayer for query %s failed %v", queryName, err)
+	}
+	defer r.Body.Close()
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("get plan replayer for query %s failed %v", queryName, err)
+	}
+	err = w.writeDataIntoZW(b, queryName)
+	if err != nil {
+		return fmt.Errorf("dump plan replayer for %s failed %v", queryName, err)
+	}
+	return nil
+}
+
+func (w *Workloader) IsPlanReplayerDumpEnabled() bool {
+	return w.cfg.EnablePlanReplayer
+}
+
+func (w *Workloader) PreparePlanReplayerDump() error {
+	if w.cfg.PlanReplayerDir == "" {
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		w.cfg.PlanReplayerDir = dir
+	}
+	if w.cfg.PlanReplayerFileName == "" {
+		w.cfg.PlanReplayerFileName = fmt.Sprintf("plan_replayer_%s_%s",
+			w.Name(), time.Now().Format("2006-01-02-15:04:05"))
+	}
+
+	fileName := fmt.Sprintf("%s.zip", w.cfg.PlanReplayerFileName)
+	zf, err := os.Create(filepath.Join(w.cfg.PlanReplayerDir, fileName))
+	if err != nil {
+		return err
+	}
+	w.zf = zf
+	// Create zip writer
+	w.zw.writer = zip.NewWriter(zf)
+	return nil
+}
+
+func (w *Workloader) FinishPlanReplayerDump() error {
+	w.zw.Lock()
+	err := w.zw.writer.Close()
+	if err != nil {
+		return err
+	}
+	w.zw.Unlock()
+
+	return w.zf.Close()
+}
+
+// writeDataIntoZW will dump query stats information by following format in zip
+/*
+ |-q1_time.zip
+ |-q2_time.zip
+ |-q3_time.zip
+ |-...
+*/
+func (w *Workloader) writeDataIntoZW(b []byte, queryName string) error {
+	k := make([]byte, 16)
+	//nolint: gosec
+	_, err := rand.Read(k)
+	if err != nil {
+		return err
+	}
+	key := base64.URLEncoding.EncodeToString(k)
+	w.zw.Lock()
+	defer w.zw.Unlock()
+	wr, err := w.zw.writer.Create(fmt.Sprintf("%v_%v_%v.zip",
+		queryName, time.Now().Format("2006-01-02-15:04:05"), key))
+	if err != nil {
+		return err
+	}
+	_, err = wr.Write(b)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
[Plan replayer](https://docs.pingcap.com/tidb/dev/sql-plan-replayer#use-plan-replayer-to-save-and-restore-the-on-site-information-of-a-cluster) is to help us reproduce the environment which is used by optimizer to decide how to generate Plan for each query. This is quite useful for us to debug if the plan unexpected changed.

This requests supports dump plan replatyer for tpch test.

The dumped zip file saved the following file:
/*
 |-q1_time.zip (plan replayer results for q1)
 |-q2_time.zip
 |-q3_time.zip
 |-...
*/ 

As we need status port to download plan replayer results from tidb-server, a quick example is like fowllowing:

```sh
go-tpc tpch --sf=1 run -H <host> -P 4000 -S 10080 --use-plan-replayer true
```