### PR TITLE
support plan replayer for ch,rawsql

### DIFF
--- a/ch/ddl.go
+++ b/ch/ddl.go
@@ -22,7 +22,7 @@ func (w *Workloader) createTableDDL(ctx context.Context, query string, tableName
 }
 
 // createTables creates tables schema.
-func (w Workloader) createTables(ctx context.Context) error {
+func (w *Workloader) createTables(ctx context.Context) error {
 	query := `
 CREATE TABLE IF NOT EXISTS nation (
     N_NATIONKEY BIGINT NOT NULL,

--- a/cmd/go-tpc/ch_benchmark.go
+++ b/cmd/go-tpc/ch_benchmark.go
@@ -73,6 +73,16 @@ func registerCHBenchmark(root *cobra.Command) {
 		false,
 		"Use Plan Replayer to dump stats and variables before running queries")
 
+	cmdRun.PersistentFlags().StringVar(&chConfig.PlanReplayerConfig.PlanReplayerDir,
+		"plan-replayer-dir",
+		"",
+		"Dir of Plan Replayer file dumps")
+
+	cmdRun.PersistentFlags().StringVar(&chConfig.PlanReplayerConfig.PlanReplayerFileName,
+		"plan-replayer-file",
+		"",
+		"Name of plan Replayer file dumps")
+
 	cmdRun.PersistentFlags().IntSliceVar(&tpccConfig.Weight, "weight", []int{45, 43, 4, 4, 4}, "Weight for NewOrder, Payment, OrderStatus, Delivery, StockLevel")
 	cmd.AddCommand(cmdRun, cmdPrepare)
 	root.AddCommand(cmd)

--- a/cmd/go-tpc/ch_benchmark.go
+++ b/cmd/go-tpc/ch_benchmark.go
@@ -68,6 +68,11 @@ func registerCHBenchmark(root *cobra.Command) {
 			executeCH("run")
 		},
 	}
+	cmdRun.PersistentFlags().BoolVar(&chConfig.EnablePlanReplayer,
+		"use-plan-replayer",
+		false,
+		"Use Plan Replayer to dump stats and variables before running queries")
+
 	cmdRun.PersistentFlags().IntSliceVar(&tpccConfig.Weight, "weight", []int{45, 43, 4, 4, 4}, "Weight for NewOrder, Payment, OrderStatus, Delivery, StockLevel")
 	cmd.AddCommand(cmdRun, cmdPrepare)
 	root.AddCommand(cmd)
@@ -85,8 +90,11 @@ func executeCH(action string) {
 	tpccConfig.Threads = threads
 	tpccConfig.Isolation = isolationLevel
 	chConfig.OutputStyle = outputStyle
+	chConfig.Driver = driver
 	chConfig.DBName = dbName
 	chConfig.QueryNames = strings.Split(chConfig.RawQueries, ",")
+	chConfig.PlanReplayerConfig.Host = host
+	chConfig.PlanReplayerConfig.StatusPort = statusPort
 
 	var (
 		tp, ap workload.Workloader

--- a/cmd/go-tpc/rawsql.go
+++ b/cmd/go-tpc/rawsql.go
@@ -36,6 +36,22 @@ func registerRawsql(root *cobra.Command) {
 			execRawsql("run")
 		},
 	}
+
+	cmdRun.PersistentFlags().BoolVar(&rawsqlConfig.EnablePlanReplayer,
+		"use-plan-replayer",
+		false,
+		"Use Plan Replayer to dump stats and variables before running queries")
+
+	cmdRun.PersistentFlags().StringVar(&rawsqlConfig.PlanReplayerConfig.PlanReplayerDir,
+		"plan-replayer-dir",
+		"",
+		"Dir of Plan Replayer file dumps")
+
+	cmdRun.PersistentFlags().StringVar(&rawsqlConfig.PlanReplayerConfig.PlanReplayerFileName,
+		"plan-replayer-file",
+		"",
+		"Name of plan Replayer file dumps")
+
 	cmdRun.PersistentFlags().StringVar(&queryFiles,
 		"query-files",
 		"",
@@ -67,6 +83,8 @@ func execRawsql(action string) {
 	rawsqlConfig.QueryNames = strings.Split(queryFiles, ",")
 	rawsqlConfig.Queries = make(map[string]string, len(rawsqlConfig.QueryNames))
 	rawsqlConfig.RefreshWait = refreshConnWait
+	rawsqlConfig.PlanReplayerConfig.Host = host
+	rawsqlConfig.PlanReplayerConfig.StatusPort = statusPort
 
 	for i, filename := range rawsqlConfig.QueryNames {
 		queryData, err := ioutil.ReadFile(filename)

--- a/cmd/go-tpc/tpch.go
+++ b/cmd/go-tpc/tpch.go
@@ -119,7 +119,7 @@ func registerTpch(root *cobra.Command) {
 			executeTpch("run")
 		},
 	}
-	
+
 	cmdRun.PersistentFlags().BoolVar(&tpchConfig.EnablePlanReplayer,
 		"use-plan-replayer",
 		false,

--- a/cmd/go-tpc/tpch.go
+++ b/cmd/go-tpc/tpch.go
@@ -21,8 +21,8 @@ func executeTpch(action string) {
 		os.Exit(1)
 	}
 
-	tpchConfig.Host = host
-	tpchConfig.StatusPort = statusPort
+	tpchConfig.PlanReplayerConfig.Host = host
+	tpchConfig.PlanReplayerConfig.StatusPort = statusPort
 
 	tpchConfig.OutputStyle = outputStyle
 	tpchConfig.Driver = driver
@@ -63,17 +63,12 @@ func registerTpch(root *cobra.Command) {
 		false,
 		"Check output data, only when the scale factor equals 1")
 
-	cmd.PersistentFlags().BoolVar(&tpchConfig.EnablePlanReplayer,
-		"use-plan-replayer",
-		false,
-		"Use Plan Replayer to dump stats and variables before running queries")
-
-	cmd.PersistentFlags().StringVar(&tpchConfig.PlanReplayerDir,
+	cmd.PersistentFlags().StringVar(&tpchConfig.PlanReplayerConfig.PlanReplayerDir,
 		"plan-replayer-dir",
 		"",
 		"Dir of Plan Replayer file dumps")
 
-	cmd.PersistentFlags().StringVar(&tpchConfig.PlanReplayerFileName,
+	cmd.PersistentFlags().StringVar(&tpchConfig.PlanReplayerConfig.PlanReplayerFileName,
 		"plan-replayer-file",
 		"",
 		"Name of plan Replayer file dumps")
@@ -124,6 +119,11 @@ func registerTpch(root *cobra.Command) {
 			executeTpch("run")
 		},
 	}
+	
+	cmdRun.PersistentFlags().BoolVar(&tpchConfig.EnablePlanReplayer,
+		"use-plan-replayer",
+		false,
+		"Use Plan Replayer to dump stats and variables before running queries")
 
 	var cmdCleanup = &cobra.Command{
 		Use:   "cleanup",

--- a/cmd/go-tpc/tpch.go
+++ b/cmd/go-tpc/tpch.go
@@ -63,16 +63,6 @@ func registerTpch(root *cobra.Command) {
 		false,
 		"Check output data, only when the scale factor equals 1")
 
-	cmd.PersistentFlags().StringVar(&tpchConfig.PlanReplayerConfig.PlanReplayerDir,
-		"plan-replayer-dir",
-		"",
-		"Dir of Plan Replayer file dumps")
-
-	cmd.PersistentFlags().StringVar(&tpchConfig.PlanReplayerConfig.PlanReplayerFileName,
-		"plan-replayer-file",
-		"",
-		"Name of plan Replayer file dumps")
-
 	var cmdPrepare = &cobra.Command{
 		Use:   "prepare",
 		Short: "Prepare data for the workload",
@@ -124,6 +114,16 @@ func registerTpch(root *cobra.Command) {
 		"use-plan-replayer",
 		false,
 		"Use Plan Replayer to dump stats and variables before running queries")
+
+	cmdRun.PersistentFlags().StringVar(&tpchConfig.PlanReplayerConfig.PlanReplayerDir,
+		"plan-replayer-dir",
+		"",
+		"Dir of Plan Replayer file dumps")
+
+	cmdRun.PersistentFlags().StringVar(&tpchConfig.PlanReplayerConfig.PlanReplayerFileName,
+		"plan-replayer-file",
+		"",
+		"Name of plan Replayer file dumps")
 
 	var cmdCleanup = &cobra.Command{
 		Use:   "cleanup",

--- a/pkg/plan-replayer/replayer.go
+++ b/pkg/plan-replayer/replayer.go
@@ -1,0 +1,126 @@
+package plan_replayer
+
+import (
+	"archive/zip"
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+type PlanReplayerConfig struct {
+	Host                 string
+	StatusPort           int
+	WorkloadName         string
+	PlanReplayerDir      string
+	PlanReplayerFileName string
+}
+
+type PlanReplayerRunner struct {
+	Config PlanReplayerConfig
+	zf     *os.File
+	zw     struct {
+		sync.Mutex
+		writer *zip.Writer
+	}
+}
+
+func (r *PlanReplayerRunner) Prepare() error {
+	if r.Config.PlanReplayerDir == "" {
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		r.Config.PlanReplayerDir = dir
+	}
+	if r.Config.PlanReplayerFileName == "" {
+		r.Config.PlanReplayerFileName = fmt.Sprintf("plan_replayer_%s_%s",
+			r.Config.WorkloadName, time.Now().Format("2006-01-02-15:04:05"))
+	}
+
+	fileName := fmt.Sprintf("%s.zip", r.Config.PlanReplayerFileName)
+	zf, err := os.Create(filepath.Join(r.Config.PlanReplayerDir, fileName))
+	if err != nil {
+		return err
+	}
+	r.zf = zf
+	// Create zip writer
+	r.zw.writer = zip.NewWriter(zf)
+	return nil
+}
+
+func (r *PlanReplayerRunner) Finish() error {
+	r.zw.Lock()
+	err := r.zw.writer.Close()
+	if err != nil {
+		return err
+	}
+	r.zw.Unlock()
+	return r.zf.Close()
+}
+
+func (r *PlanReplayerRunner) Dump(ctx context.Context, conn *sql.Conn, query, queryName string) error {
+	rows, err := conn.QueryContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("execute query %s failed %v", query, err)
+	}
+	defer rows.Close()
+	var token string
+	for rows.Next() {
+		err := rows.Scan(&token)
+		if err != nil {
+			return fmt.Errorf("execute query %s failed %v", query, err)
+		}
+	}
+	// TODO: support tls
+	resp, err := http.Get(fmt.Sprintf("http://%s:%v/plan_replayer/dump/%s", r.Config.Host, r.Config.StatusPort, token))
+	if err != nil {
+		return fmt.Errorf("get plan replayer for query %s failed %v", queryName, err)
+	}
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("get plan replayer for query %s failed %v", queryName, err)
+	}
+	err = r.writeDataIntoZW(b, queryName)
+	if err != nil {
+		return fmt.Errorf("dump plan replayer for %s failed %v", queryName, err)
+	}
+	return nil
+}
+
+// writeDataIntoZW will dump query stats information by following format in zip
+/*
+ |-q1_time.zip
+ |-q2_time.zip
+ |-q3_time.zip
+ |-...
+*/
+func (r *PlanReplayerRunner) writeDataIntoZW(b []byte, queryName string) error {
+	k := make([]byte, 16)
+	//nolint: gosec
+	_, err := rand.Read(k)
+	if err != nil {
+		return err
+	}
+	key := base64.URLEncoding.EncodeToString(k)
+	r.zw.Lock()
+	defer r.zw.Unlock()
+	wr, err := r.zw.writer.Create(fmt.Sprintf("%v_%v_%v.zip",
+		queryName, time.Now().Format("2006-01-02-15:04:05"), key))
+	if err != nil {
+		return err
+	}
+	_, err = wr.Write(b)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/rawsql/workload.go
+++ b/rawsql/workload.go
@@ -186,7 +186,7 @@ func (w *Workloader) Check(ctx context.Context, threadID int) error {
 }
 
 func (w *Workloader) dumpPlanReplayer(ctx context.Context, s *rawsqlState, query, queryName string) error {
-	query = strings.Replace(query, "/*PLACEHOLDER*/", "plan replayer dump explain", 1)
+	query = "plan replayer dump explain " + query
 	return w.PlanReplayerRunner.Dump(ctx, s.Conn, query, queryName)
 }
 


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

support plan replayer for ch like following:

```sh
go-tpc ch --warehouses <warehouses> -T <count> -t <count> --time <time> -H <host> -P <dbPort> -D <database> -S <statusPort> --use-plan-replayer true run
```

support plan replayer for rawsql like following:

```sh
go-tpc  rawsql run --query-files q1.sql --time <time> -H <host> -P <dbPort> -D <database> -S <statusPort> --use-plan-replayer true
```