### PR TITLE
*: support for connecting to multple instances directly

### DIFF
--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -2,11 +2,16 @@ package main
 
 import (
 	"context"
+	"crypto/sha1"
 	"database/sql"
+	sqldrv "database/sql/driver"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -14,15 +19,15 @@ import (
 	"github.com/spf13/cobra"
 
 	// mysql package
-	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-sql-driver/mysql"
 	// pg
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 )
 
 var (
 	dbName         string
-	host           string
-	port           int
+	hosts          []string
+	ports          []int
 	statusPort     int
 	user           string
 	password       string
@@ -41,6 +46,7 @@ var (
 	maxProcs       int
 	connParams     string
 	outputStyle    string
+	targets        []string
 
 	globalDB  *sql.DB
 	globalCtx context.Context
@@ -52,6 +58,77 @@ const (
 	pgDriver    = "postgres"
 )
 
+type MuxDriver struct {
+	cursor    uint64
+	instances []string
+	internal  sqldrv.Driver
+}
+
+func (drv *MuxDriver) Open(name string) (sqldrv.Conn, error) {
+	k := atomic.AddUint64(&drv.cursor, 1)
+	return drv.internal.Open(drv.instances[int(k)%len(drv.instances)])
+}
+
+func makeTargets(hosts []string, ports []int) []string {
+	targets := make([]string, 0, len(hosts)*len(ports))
+	for _, host := range hosts {
+		for _, port := range ports {
+			targets = append(targets, host+":"+strconv.Itoa(port))
+		}
+	}
+	return targets
+}
+
+func newDB(targets []string, driver string, user string, password string, dbName string, connParams string) (*sql.DB, error) {
+	if len(targets) == 0 {
+		panic(fmt.Errorf("empty targets"))
+	}
+	var (
+		drv   sqldrv.Driver
+		hash  = sha1.New()
+		names = make([]string, len(targets))
+	)
+	hash.Write([]byte(driver))
+	hash.Write([]byte(user))
+	hash.Write([]byte(password))
+	hash.Write([]byte(dbName))
+	hash.Write([]byte(connParams))
+	for i, addr := range targets {
+		hash.Write([]byte(addr))
+		switch driver {
+		case mysqlDriver:
+			// allow multiple statements in one query to allow q15 on the TPC-H
+			dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?multiStatements=true", user, password, addr, dbName)
+			if len(connParams) > 0 {
+				dsn = dsn + "&" + connParams
+			}
+			names[i] = dsn
+			drv = &mysql.MySQLDriver{}
+		case pgDriver:
+			dsn := fmt.Sprintf("postgres://%s:%s@%s/%s", user, password, addr, dbName)
+			if len(connParams) > 0 {
+				dsn = dsn + "?" + connParams
+			}
+			names[i] = dsn
+			drv = &pq.Driver{}
+		default:
+			panic(fmt.Errorf("unknown driver: %q", driver))
+		}
+	}
+
+	if len(names) == 1 {
+		return sql.Open(driver, names[0])
+	}
+	drvName := driver + "+" + hex.EncodeToString(hash.Sum(nil))
+	for _, n := range sql.Drivers() {
+		if n == drvName {
+			return sql.Open(drvName, "")
+		}
+	}
+	sql.Register(drvName, &MuxDriver{instances: names, internal: drv})
+	return sql.Open(drvName, "")
+}
+
 func closeDB() {
 	if globalDB != nil {
 		globalDB.Close()
@@ -59,29 +136,27 @@ func closeDB() {
 	globalDB = nil
 }
 
-func buildDSN(tmp bool) string {
-	switch driver {
-	case mysqlDriver:
-		if tmp {
-			return fmt.Sprintf("%s:%s@tcp(%s:%d)/", user, password, host, port)
+func openDB() {
+	var (
+		tmpDB *sql.DB
+		err   error
+	)
+	globalDB, err = newDB(targets, driver, user, password, dbName, connParams)
+	if err != nil {
+		panic(err)
+	}
+	if err := globalDB.Ping(); err != nil {
+		if isDBNotExist(err) {
+			tmpDB, _ = newDB(targets, driver, user, password, "", connParams)
+			defer tmpDB.Close()
+			if _, err := tmpDB.Exec(createDBDDL + dbName); err != nil {
+				panic(fmt.Errorf("failed to create database, err %v\n", err))
+			}
+		} else {
+			globalDB = nil
 		}
-		// allow multiple statements in one query to allow q15 on the TPC-H
-		dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?multiStatements=true", user, password, host, port, dbName)
-		if len(connParams) > 0 {
-			dsn = dsn + "&" + connParams
-		}
-		return dsn
-	case pgDriver:
-		if tmp {
-			return fmt.Sprintf("postgres://%s:%s@%s:%d/?%s", user, password, host, port, connParams)
-		}
-		dsn := fmt.Sprintf("postgres://%s:%s@%s:%d/%s", user, password, host, port, dbName)
-		if len(connParams) > 0 {
-			dsn = dsn + "?" + connParams
-		}
-		return dsn
-	default:
-		panic(fmt.Errorf("unknown driver: %q", driver))
+	} else {
+		globalDB.SetMaxIdleConns(threads + acThreads + 1)
 	}
 }
 
@@ -99,43 +174,24 @@ func isDBNotExist(err error) bool {
 	return false
 }
 
-func openDB() {
-	var (
-		tmpDB *sql.DB
-		err   error
-	)
-	globalDB, err = sql.Open(driver, buildDSN(false))
-	if err != nil {
-		panic(err)
-	}
-	if err := globalDB.Ping(); err != nil {
-		if isDBNotExist(err) {
-			tmpDB, _ = sql.Open(driver, buildDSN(true))
-			defer tmpDB.Close()
-			if _, err := tmpDB.Exec(createDBDDL + dbName); err != nil {
-				panic(fmt.Errorf("failed to create database, err %v\n", err))
-			}
-		} else {
-			globalDB = nil
-		}
-	} else {
-		globalDB.SetMaxIdleConns(threads + acThreads + 1)
-	}
-}
-
 func main() {
 	var rootCmd = &cobra.Command{
 		Use:   "go-tpc",
 		Short: "Benchmark database with different workloads",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if len(targets) == 0 {
+				targets = makeTargets(hosts, ports)
+			}
+		},
 	}
 	rootCmd.PersistentFlags().IntVar(&maxProcs, "max-procs", 0, "runtime.GOMAXPROCS")
 	rootCmd.PersistentFlags().StringVar(&pprofAddr, "pprof", "", "Address of pprof endpoint")
 	rootCmd.PersistentFlags().StringVar(&metricsAddr, "metrics-addr", "", "Address of metrics endpoint")
 	rootCmd.PersistentFlags().StringVarP(&dbName, "db", "D", "test", "Database name")
-	rootCmd.PersistentFlags().StringVarP(&host, "host", "H", "127.0.0.1", "Database host")
+	rootCmd.PersistentFlags().StringSliceVarP(&hosts, "host", "H", []string{"127.0.0.1"}, "Database host")
 	rootCmd.PersistentFlags().StringVarP(&user, "user", "U", "root", "Database user")
 	rootCmd.PersistentFlags().StringVarP(&password, "password", "p", "", "Database password")
-	rootCmd.PersistentFlags().IntVarP(&port, "port", "P", 4000, "Database port")
+	rootCmd.PersistentFlags().IntSliceVarP(&ports, "port", "P", []int{4000}, "Database port")
 	rootCmd.PersistentFlags().IntVarP(&statusPort, "statusPort", "S", 10080, "Database status port")
 	rootCmd.PersistentFlags().IntVarP(&threads, "threads", "T", 1, "Thread concurrency")
 	rootCmd.PersistentFlags().IntVarP(&acThreads, "acThreads", "t", 1, "OLAP client concurrency, only for CH-benCHmark")
@@ -151,6 +207,8 @@ func main() {
 5: Snapshot, 6: Serializable, 7: Linerizable`)
 	rootCmd.PersistentFlags().StringVar(&connParams, "conn-params", "", "session variables, e.g. for TiDB --conn-params tidb_isolation_read_engines='tiflash', For PostgreSQL: --conn-params sslmode=disable")
 	rootCmd.PersistentFlags().StringVar(&outputStyle, "output", util.OutputStylePlain, "output style, valid values can be { plain | table | json }")
+	rootCmd.PersistentFlags().StringSliceVar(&targets, "targets", nil, "Target database addresses")
+	rootCmd.PersistentFlags().MarkHidden("targets")
 
 	cobra.EnablePrefixMatching = true
 

--- a/cmd/go-tpc/rawsql.go
+++ b/cmd/go-tpc/rawsql.go
@@ -83,7 +83,7 @@ func execRawsql(action string) {
 	rawsqlConfig.QueryNames = strings.Split(queryFiles, ",")
 	rawsqlConfig.Queries = make(map[string]string, len(rawsqlConfig.QueryNames))
 	rawsqlConfig.RefreshWait = refreshConnWait
-	rawsqlConfig.PlanReplayerConfig.Host = host
+	rawsqlConfig.PlanReplayerConfig.Host = hosts[0]
 	rawsqlConfig.PlanReplayerConfig.StatusPort = statusPort
 
 	for i, filename := range rawsqlConfig.QueryNames {

--- a/cmd/go-tpc/tpch.go
+++ b/cmd/go-tpc/tpch.go
@@ -21,7 +21,7 @@ func executeTpch(action string) {
 		os.Exit(1)
 	}
 
-	tpchConfig.PlanReplayerConfig.Host = host
+	tpchConfig.PlanReplayerConfig.Host = hosts[0]
 	tpchConfig.PlanReplayerConfig.StatusPort = statusPort
 
 	tpchConfig.OutputStyle = outputStyle


### PR DESCRIPTION
Allow specifying a list of hosts & ports to connect to (just like sysbench), eg. `--host 172.16.4.1,172.16.4.2 --port 4000,4001` means connecting to 172.16.4.1:4000, 172.16.4.1:4001, 172.16.4.2:4000, 172.16.4.2:4001 round-robin.

![2022-10-09_171038](https://user-images.githubusercontent.com/6850317/194748334-e188354f-46fa-4d9c-b490-a8afb075f6b5.png)
