### PR TITLE
*: set right GOMAXPROCS

### DIFF
--- a/cmd/go-tpc/ch_benchmark.go
+++ b/cmd/go-tpc/ch_benchmark.go
@@ -116,7 +116,9 @@ func registerCHBenchmark(root *cobra.Command) {
 }
 
 func executeCH(action string, openAP func() (*sql.DB, error)) {
-	runtime.GOMAXPROCS(maxProcs)
+	if maxProcs == 0 {
+		runtime.GOMAXPROCS(maxProcs)
+	}
 
 	openDB()
 	defer closeDB()

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/pingcap/go-tpc/pkg/util"
 	"github.com/spf13/cobra"
-
+	_ "go.uber.org/automaxprocs"
 	// mysql package
 	"github.com/go-sql-driver/mysql"
 	// pg

--- a/cmd/go-tpc/tpcc.go
+++ b/cmd/go-tpc/tpcc.go
@@ -39,7 +39,9 @@ func executeTpcc(action string) {
 			}
 		}()
 	}
-	runtime.GOMAXPROCS(maxProcs)
+	if maxProcs == 0 {
+		runtime.GOMAXPROCS(maxProcs)
+	}
 
 	openDB()
 	defer closeDB()

--- a/cmd/go-tpc/tpch.go
+++ b/cmd/go-tpc/tpch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/pingcap/go-tpc/pkg/util"
@@ -20,6 +21,9 @@ func executeTpch(action string) {
 	if globalDB == nil {
 		util.StdErrLogger.Printf("cannot connect to the database")
 		os.Exit(1)
+	}
+	if maxProcs == 0 {
+		runtime.GOMAXPROCS(maxProcs)
 	}
 
 	tpchConfig.PlanReplayerConfig.Host = hosts[0]

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/atomic v1.9.0
+	go.uber.org/automaxprocs v1.5.3
 	golang.org/x/sync v0.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -301,6 +301,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
+github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.15.0 h1:5fCgGYogn0hFdhyhLbw7hEsWxufKtY9klyvdNfFlFhM=

--- a/go.sum
+++ b/go.sum
@@ -300,6 +300,7 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.15.0 h1:5fCgGYogn0hFdhyhLbw7hEsWxufKtY9klyvdNfFlFhM=
@@ -409,6 +410,8 @@ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/automaxprocs v1.5.3 h1:kWazyxZUrS3Gs4qUpbwo5kEIMGe/DAvi5Z4tl2NW4j8=
+go.uber.org/automaxprocs v1.5.3/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=


### PR DESCRIPTION
In containerized deployments, Go runtime, by default, uses the total number of CPU cores available on the machine as the value of GOMAXPROCS, without considering the CPU quota of the container. This can lead to suboptimal performance and potential throttling issues as more goroutines may get scheduled than the available CPU quota.

Uber's automaxprocs library automatically adjusts the GOMAXPROCS value to match the Linux container's CPU quota, leading to more efficient CPU usage and potentially better performance.