### PR TITLE
*: Support building multi-arch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the go-tpc binary
-FROM golang:1.18 as builder
+FROM golang:1.21 as builder
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -12,9 +12,10 @@ RUN go mod download
 COPY . .
 
 # Build
-RUN GOOS=linux GOARCH=amd64 make build
+ARG TARGETOS TARGETARCH
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH make build
 
-FROM pingcap/alpine-glibc:3.10
+FROM alpine
 
 RUN apk add --no-cache \
   dumb-init \

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ GOBUILD=$(GO) build -ldflags '$(LDFLAGS)'
 
 # Image URL to use all building/pushing image targets
 IMG ?= go-tpc:latest
+PLATFORM ?= linux/amd64,linux/arm64
 
 all: format test build
 
@@ -42,3 +43,8 @@ docker-build: test
 
 docker-push: docker-build
 	docker push ${IMG}
+
+# Create multiarch driver if not exists:
+#   docker buildx create --name multiarch --driver docker-container --use
+docker-multiarch: test
+	docker buildx build --platform ${PLATFORM} . -t ${IMG} --push


### PR DESCRIPTION
### Manual Test

```
> make docker-buildx IMG=hub.pingcap.net/go-tpc/go-tpc:latest
...
...
 => [linux/arm64 builder 7/7] RUN GOOS=linux GOARCH=arm64 make build                                                                                                                                                                                                                             114.1s
 => [linux/amd64 builder 6/7] COPY . .                                                                                                                                                                                                                                                             0.1s
 => [linux/amd64 builder 7/7] RUN GOOS=linux GOARCH=amd64 make build                                                                                                                                                                                                                              10.5s
 => [linux/amd64 stage-1 3/3] COPY --from=builder /workspace/bin/go-tpc /go-tpc                                                                                                                                                                                                                    0.0s
 => [linux/arm64 stage-1 3/3] COPY --from=builder /workspace/bin/go-tpc /go-tpc                                                                                                                                                                                                                    0.1s
 => exporting to image                                                                                                                                                                                                                                                                            11.4s
...
...
```

<img width="1094" alt="image" src="https://github.com/pingcap/go-tpc/assets/1907938/84293aae-d2b9-4862-af81-a324f4e6a3ef">

Regression Test:

```
> make docker-build
...
...
 => [stage-1 2/3] RUN apk add --no-cache   dumb-init   tzdata   mariadb-client                                                                                                                                                                                                   37.0s
 => [builder 2/7] WORKDIR /workspace                                                                                                                                                                                                                                              0.6s 
 => [builder 3/7] COPY go.mod go.mod                                                                                                                                                                                                                                              0.0s
 => [builder 4/7] COPY go.sum go.sum                                                                                                                                                                                                                                              0.0s
 => [builder 5/7] RUN go mod download                                                                                                                                                                                                                                             4.4s
 => [builder 6/7] COPY . .                                                                                                                                                                                                                                                        0.1s
 => [builder 7/7] RUN GOOS=linux GOARCH=amd64 make build                                                                                                                                                                                                                         11.0s
 => [stage-1 3/3] COPY --from=builder /workspace/bin/go-tpc /go-tpc                                                                                                                                                                                                               0.0s
 => exporting to image                                                                                                                                                                                                                                                            0.5s
 => => exporting layers                                                                                                                                                                                                                                                           0.5s
 => => writing image sha256:8e411f671534ce7c987794abdedc8b5b882563ed3fb7c8f15302732c94ec460e                                                                                                                                                                                      0.0s
 => => naming to docker.io/library/go-tpc:latest                                                                                                                                                                                                                                  0.0s
...
...
```
