### PR TITLE
tpch: add query tuning configs for tpch

### DIFF
--- a/cmd/go-tpc/tpch.go
+++ b/cmd/go-tpc/tpch.go
@@ -34,6 +34,7 @@ func executeTpch(action string) {
 	tpchConfig.DBName = dbName
 	tpchConfig.PrepareThreads = threads
 	tpchConfig.QueryNames = strings.Split(tpchConfig.RawQueries, ",")
+	tpchConfig.QueryTuningConfig.Vars = strings.Split(tpchConfig.QueryTuningConfig.VarsRaw, ";")
 	w := tpch.NewWorkloader(globalDB, &tpchConfig)
 	timeoutCtx, cancel := context.WithTimeout(globalCtx, totalTime)
 	defer cancel()
@@ -129,6 +130,15 @@ func registerTpch(root *cobra.Command) {
 		"plan-replayer-file",
 		"",
 		"Name of plan Replayer file dumps")
+
+	cmdPrepare.PersistentFlags().BoolVar(&tpchConfig.QueryTuningConfig.Enable,
+		"enable-query-tuning",
+		true,
+		"Enable query tuning by setting specified session variables")
+	cmdPrepare.PersistentFlags().StringVar(&tpchConfig.QueryTuningConfig.VarsRaw,
+		"query-tuning-vars",
+		"tidb_default_string_match_selectivity=0.1;tidb_opt_join_reorder_threshold=60;tidb_prefer_broadcast_join_by_exchange_data_size=ON",
+		"Specify a sequence of session variables to set before executing each query, in the form of 'name=value', separated by semicolon. Defaulted to some variables known effective for tpch queries.")
 
 	var cmdCleanup = &cobra.Command{
 		Use:   "cleanup",

--- a/cmd/go-tpc/tpch.go
+++ b/cmd/go-tpc/tpch.go
@@ -131,11 +131,11 @@ func registerTpch(root *cobra.Command) {
 		"",
 		"Name of plan Replayer file dumps")
 
-	cmdPrepare.PersistentFlags().BoolVar(&tpchConfig.QueryTuningConfig.Enable,
+	cmdRun.PersistentFlags().BoolVar(&tpchConfig.QueryTuningConfig.Enable,
 		"enable-query-tuning",
 		true,
 		"Enable query tuning by setting specified session variables")
-	cmdPrepare.PersistentFlags().StringVar(&tpchConfig.QueryTuningConfig.VarsRaw,
+	cmdRun.PersistentFlags().StringVar(&tpchConfig.QueryTuningConfig.VarsRaw,
 		"query-tuning-vars",
 		"tidb_default_string_match_selectivity=0.1;tidb_opt_join_reorder_threshold=60;tidb_prefer_broadcast_join_by_exchange_data_size=ON",
 		"Specify a sequence of session variables to set before executing each query, in the form of 'name=value', separated by semicolon. Defaulted to some variables known effective for tpch queries.")

--- a/tpch/workload.go
+++ b/tpch/workload.go
@@ -206,7 +206,7 @@ func (w *Workloader) CheckPrepare(ctx context.Context, threadID int) error {
 }
 
 func (w *Workloader) setQueryTuningVars(ctx context.Context) error {
-	if w.cfg.QueryTuningConfig.Enable && w.cfg.Driver != "mysql" {
+	if w.cfg.QueryTuningConfig.Enable && w.cfg.Driver == "mysql" {
 		conn := w.getState(ctx).Conn
 		for _, v := range w.cfg.QueryTuningConfig.Vars {
 			if _, err := conn.ExecContext(ctx, fmt.Sprintf("SET @@session.%s", v)); err != nil {

--- a/tpch/workload.go
+++ b/tpch/workload.go
@@ -29,6 +29,12 @@ type analyzeConfig struct {
 	IndexSerialScanConcurrency int
 }
 
+type queryTuningConfig struct {
+	Enable  bool
+	VarsRaw string
+	Vars    []string
+}
+
 // Config is the configuration for tpch workload
 type Config struct {
 	Driver             string
@@ -44,6 +50,8 @@ type Config struct {
 
 	PlanReplayerConfig replayer.PlanReplayerConfig
 	EnablePlanReplayer bool
+
+	QueryTuningConfig queryTuningConfig
 
 	// for prepare command only
 	OutputType string
@@ -197,6 +205,18 @@ func (w *Workloader) CheckPrepare(ctx context.Context, threadID int) error {
 	return nil
 }
 
+func (w *Workloader) setQueryTuningVars(ctx context.Context) error {
+	if w.cfg.QueryTuningConfig.Enable && w.cfg.Driver != "mysql" {
+		conn := w.getState(ctx).Conn
+		for _, v := range w.cfg.QueryTuningConfig.Vars {
+			if _, err := conn.ExecContext(ctx, fmt.Sprintf("SET @@session.%s", v)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // Run runs workload
 func (w *Workloader) Run(ctx context.Context, threadID int) error {
 	s := w.getState(ctx)
@@ -205,6 +225,10 @@ func (w *Workloader) Run(ctx context.Context, threadID int) error {
 		if err := s.RefreshConn(ctx); err != nil {
 			return err
 		}
+	}
+
+	if err := w.setQueryTuningVars(ctx); err != nil {
+		return fmt.Errorf("set query tuning variables failed %v", err)
 	}
 
 	queryName := w.cfg.QueryNames[s.queryIdx%len(w.cfg.QueryNames)]


### PR DESCRIPTION
Set some session variables known to be effective for tpch before each tpch query to tune performance. And also add flags to turn it on/off and override the default variables.

```
      --enable-query-tuning         Enable query tuning by setting specified session variables (default true)
```
`tidb_default_string_match_selectivity=0.1`: For optimal join order, esp. q9.
`tidb_opt_join_reorder_threshold=60`: For general optimal join order.
`tidb_prefer_broadcast_join_by_exchange_data_size=ON`: For better join type between broadcast join and partition join.