### PR TITLE
Add tls support for mysql client

### DIFF
--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -298,7 +298,7 @@ func registerMysqlTLSConfig() {
 
 	// Append the certificates from the CA
 	if !certPool.AppendCertsFromPEM(ca) {
-		panic(fmt.Errorf("failed to append ca certs"))
+		panic(fmt.Errorf("failed to append CA certs"))
 	}
 
 	tlsConfig := &tls.Config{

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -101,7 +101,7 @@ func newDB(targets []string, driver string, user string, password string, dbName
 	hash.Write([]byte(dbName))
 	hash.Write([]byte(connParams))
 
-	if driver == mysqlDriver && (len(sslCA) > 0 || len(sslCert) >0 || len(sslKey) > 0) {
+	if driver == mysqlDriver && (len(sslCA) > 0 || len(sslCert) > 0 || len(sslKey) > 0) {
 		registerMysqlTLSConfig()
 	}
 

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -121,7 +121,7 @@ func newDB(targets []string, driver string, user string, password string, dbName
 			names[i] = dsn
 			drv = &mysql.MySQLDriver{}
 		case pgDriver:
-			if len(sslCA) > 0 {
+			if len(sslCA) > 0 || len(sslKey) > 0 || len(sslCert) > 0 {
 				panic("postgresql driver doesn't support TLS yet")
 			}
 

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -302,7 +302,7 @@ func registerMysqlTLSConfig() {
 	}
 
 	tlsConfig := &tls.Config{
-		MinVersion:   tls.VersionTLS10,
+		MinVersion:   tls.VersionTLS12,
 		Certificates: certificates,
 		RootCAs:      certPool,
 		ClientCAs:    certPool,

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -311,6 +311,6 @@ func registerMysqlTLSConfig() {
 
 	err = mysql.RegisterTLSConfig(customTlsName, tlsConfig)
 	if err != nil {
-		panic(fmt.Errorf("failed to register TLS configs, err %v", err))
+		panic(fmt.Errorf("failed to register TLS config, err %v", err))
 	}
 }

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -288,7 +288,7 @@ func registerMysqlTLSConfig() {
 		}
 		certificates = []tls.Certificate{cert}
 	} else if len(sslCert) > 0 || len(sslKey) > 0 {
-	    panic(errors.New("incomplete key pair configuration"))
+		panic("incomplete key pair configuration")
 	}
 
 	// Create a certificate pool from CA
@@ -300,7 +300,7 @@ func registerMysqlTLSConfig() {
 
 	// Append the certificates from the CA
 	if !certPool.AppendCertsFromPEM(ca) {
-		panic(fmt.Errorf("failed to append CA certs"))
+		panic("failed to append CA certs")
 	}
 
 	tlsConfig := &tls.Config{

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -306,7 +306,6 @@ func registerMysqlTLSConfig() {
 		Certificates: certificates,
 		RootCAs:      certPool,
 		ClientCAs:    certPool,
-		NextProtos:   []string{"h2", "http/1.1"}, // specify `h2` to let Go use HTTP/2.
 	}
 
 	err = mysql.RegisterTLSConfig(customTlsName, tlsConfig)

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -287,6 +287,8 @@ func registerMysqlTLSConfig() {
 			panic(fmt.Errorf("could not load client key pair, err %v", err))
 		}
 		certificates = []tls.Certificate{cert}
+	} else if len(sslCert) > 0 || len(sslKey) > 0 {
+	    panic(errors.New("incomplete key pair configuration"))
 	}
 
 	// Create a certificate pool from CA

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -101,7 +101,7 @@ func newDB(targets []string, driver string, user string, password string, dbName
 	hash.Write([]byte(dbName))
 	hash.Write([]byte(connParams))
 
-	if driver == mysqlDriver && len(sslCA) > 0 {
+	if driver == mysqlDriver && (len(sslCA) > 0 || len(sslCert) >0 || len(sslKey) > 0) {
 		registerMysqlTLSConfig()
 	}
 

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -311,6 +311,6 @@ func registerMysqlTLSConfig() {
 
 	err = mysql.RegisterTLSConfig(customTlsName, tlsConfig)
 	if err != nil {
-		panic(fmt.Errorf("failed to register ssl configs, err %v", err))
+		panic(fmt.Errorf("failed to register TLS configs, err %v", err))
 	}
 }

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -293,7 +293,7 @@ func registerMysqlTLSConfig() {
 	certPool := x509.NewCertPool()
 	ca, err := os.ReadFile(sslCA)
 	if err != nil {
-		panic(fmt.Errorf("could not read ca certificate, err %v", err))
+		panic(fmt.Errorf("could not read CA certificate, err %v", err))
 	}
 
 	// Append the certificates from the CA

--- a/cmd/go-tpc/main.go
+++ b/cmd/go-tpc/main.go
@@ -122,7 +122,7 @@ func newDB(targets []string, driver string, user string, password string, dbName
 			drv = &mysql.MySQLDriver{}
 		case pgDriver:
 			if len(sslCA) > 0 {
-				panic("postgres driver doesn't support tls yet")
+				panic("postgresql driver doesn't support TLS yet")
 			}
 
 			dsn := fmt.Sprintf("postgres://%s:%s@%s/%s", user, password, addr, dbName)


### PR DESCRIPTION
Close: #185 

Add tls config for connecting mysql with tls enabled

Manually test:
```
[ec2-user@ip-10-0-19-25 cert]$ ./go-tpc -H 10.0.153.232 -U u1 -P 4000 tpcc --warehouses 1 prepare
2024/11/23 21:42:36 maxprocs: Leaving GOMAXPROCS=4: CPU quota undefined
failed to ping db, err Error 1045 (28000): Access denied for user 'u1'@'10.0.19.25' (using password: NO)
panic: failed to connect to database when loading data

goroutine 1 [running]:
github.com/pingcap/go-tpc/tpcc.NewWorkloader(0x59c338?, 0xc0003e9540?)
        /Users/Projects/db-will/go-tpc/tpcc/workload.go:110 +0x8bd
main.executeTpcc({0xb4c776, 0x7})
        /Users/Projects/db-will/go-tpc/cmd/go-tpc/tpcc.go:66 +0x205
main.registerTpcc.func1(0xc000144900?, {0xb49b4c?, 0x4?, 0xb49b50?})
        /Users/Projects/db-will/go-tpc/cmd/go-tpc/tpcc.go:96 +0x1f
github.com/spf13/cobra.(*Command).execute(0xc0003a9b88, {0xc00012a380, 0x8, 0x8})
        /Users/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846 +0x671
github.com/spf13/cobra.(*Command).ExecuteC(0xc0003a9348)
        /Users/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x389
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
main.main()
        /Users/Projects/db-will/go-tpc/cmd/go-tpc/main.go:274 +0x846
[ec2-user@ip-10-0-19-25 cert]$ ./go-tpc -H 10.0.153.232 -U u1 -P 4000 --ssl-ca ./root.crt --ssl-cert ./client.crt --ssl-key ./client.key  tpcc --warehouses 1 clean
2024/11/23 21:42:54 maxprocs: Leaving GOMAXPROCS=4: CPU quota undefined
DROP TABLE IF EXISTS item
DROP TABLE IF EXISTS customer
DROP TABLE IF EXISTS district
DROP TABLE IF EXISTS history
DROP TABLE IF EXISTS new_order
DROP TABLE IF EXISTS order_line
DROP TABLE IF EXISTS orders
DROP TABLE IF EXISTS stock
DROP TABLE IF EXISTS warehouse
Finished
```