### PR TITLE
fix: set tidb tunning variables only when connected to valid tidb

### DIFF
--- a/cmd/go-tpc/tpch.go
+++ b/cmd/go-tpc/tpch.go
@@ -45,15 +45,20 @@ func executeTpch(action string) {
 		runtime.GOMAXPROCS(maxProcs)
 	}
 
-	if action == "run" && tpchConfig.EnableQueryTuning {
+	if action == "run" && driver == mysqlDriver && tpchConfig.EnableQueryTuning {
 		serverVer, err := getServerVersion(globalDB)
 		if err != nil {
 			panic(fmt.Errorf("get server version failed: %v", err))
 		}
+		fmt.Printf("Server version: %s\n", serverVer)
+
 		if semVer, ok := util.NewTiDBSemVersion(serverVer); ok {
+			fmt.Printf("Enabling query tuning for TiDB version %s.\n", semVer.String())
 			if err := setTiDBQueryTuningVars(globalDB, semVer); err != nil {
 				panic(fmt.Errorf("set session variables failed: %v", err))
 			}
+		} else {
+			fmt.Printf("Query tuning is enabled(by default) but server version doesn't appear to be TiDB, skipping tuning.\n")
 		}
 	}
 

--- a/cmd/go-tpc/tpch.go
+++ b/cmd/go-tpc/tpch.go
@@ -99,7 +99,7 @@ func isValidTuningVersion(version string) bool {
 	// Compare as string to handle versions with non-numeric suffixes (e.g. '7.1.0-alpha')
 	patchStr := parts[2]
 
-	if major > 1 {
+	if major > 7 {
 		return true
 	}
 	if major < 7 {

--- a/pkg/util/version.go
+++ b/pkg/util/version.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"strconv"
+	"strings"
+)
+
+type SemVersion struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+// @version is the `SELECT VERSION()` output of TiDB
+func NewTiDBSemVersion(version string) (SemVersion, bool) {
+	isTiDB := strings.Contains(strings.ToLower(version), "tidb")
+	if !isTiDB {
+		return SemVersion{}, false
+	}
+
+	verItems := strings.Split(version, "-v")
+	if len(verItems) < 2 {
+		return SemVersion{}, false
+	}
+	verStr := strings.Split(verItems[1], "-")[0]
+
+	parts := strings.Split(verStr, ".")
+	if len(parts) < 3 {
+		return SemVersion{}, false
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return SemVersion{}, false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return SemVersion{}, false
+	}
+
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return SemVersion{}, false
+	}
+
+	return SemVersion{
+		Major: major,
+		Minor: minor,
+		Patch: patch,
+	}, true
+
+}

--- a/pkg/util/version.go
+++ b/pkg/util/version.go
@@ -55,7 +55,7 @@ func (s SemVersion) String() string {
 }
 
 func (s SemVersion) Compare(other SemVersion) int {
-	sign := func(x int) int {
+	signum := func(x int) int {
 		if x > 0 {
 			return 1
 		}
@@ -66,13 +66,13 @@ func (s SemVersion) Compare(other SemVersion) int {
 	}
 
 	if diff := s.Major - other.Major; diff != 0 {
-		return sign(diff)
+		return signum(diff)
 	}
 	if diff := s.Minor - other.Minor; diff != 0 {
-		return sign(diff)
+		return signum(diff)
 	}
 	if diff := s.Patch - other.Patch; diff != 0 {
-		return sign(diff)
+		return signum(diff)
 	}
 	return 0
 }

--- a/pkg/util/version.go
+++ b/pkg/util/version.go
@@ -48,5 +48,31 @@ func NewTiDBSemVersion(version string) (SemVersion, bool) {
 		Minor: minor,
 		Patch: patch,
 	}, true
+}
 
+func (s SemVersion) String() string {
+	return strconv.Itoa(s.Major) + "." + strconv.Itoa(s.Minor) + "." + strconv.Itoa(s.Patch)
+}
+
+func (s SemVersion) Compare(other SemVersion) int {
+	sign := func(x int) int {
+		if x > 0 {
+			return 1
+		}
+		if x < 0 {
+			return -1
+		}
+		return 0
+	}
+
+	if diff := s.Major - other.Major; diff != 0 {
+		return sign(diff)
+	}
+	if diff := s.Minor - other.Minor; diff != 0 {
+		return sign(diff)
+	}
+	if diff := s.Patch - other.Patch; diff != 0 {
+		return sign(diff)
+	}
+	return 0
 }

--- a/pkg/util/version_test.go
+++ b/pkg/util/version_test.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTiDBSemVersion(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected SemVersion
+		ok       bool
+	}{
+		{
+			name:     "normal case with addition",
+			input:    "5.7.25-TiDB-v7.1.0-alpha",
+			expected: SemVersion{Major: 7, Minor: 1, Patch: 0},
+			ok:       true,
+		},
+		{
+			name:     "version without addition",
+			input:    "5.7.25-TiDB-v7.4.1",
+			expected: SemVersion{Major: 7, Minor: 4, Patch: 1},
+			ok:       true,
+		},
+		{
+			name:     "multi-part addition",
+			input:    "5.7.25-TiDB-v6.5.3-beta.2",
+			expected: SemVersion{Major: 6, Minor: 5, Patch: 3},
+			ok:       true,
+		},
+		{
+			name:     "empty addition due to trailing hyphen",
+			input:    "5.7.25-TiDB-v7.1.0-",
+			expected: SemVersion{Major: 7, Minor: 1, Patch: 0},
+			ok:       true,
+		},
+		{
+			name:     "non-tidb database",
+			input:    "MySQL 8.0.35",
+			expected: SemVersion{},
+			ok:       false,
+		},
+		{
+			name:     "missing version prefix",
+			input:    "TiDB-7.2.0",
+			expected: SemVersion{},
+			ok:       false,
+		},
+		{
+			name:     "invalid patch version",
+			input:    "5.7.25-TiDB-v7.1.x",
+			expected: SemVersion{},
+			ok:       false,
+		},
+		{
+			name:     "insufficient version parts",
+			input:    "5.7.25-TiDB-v7.1",
+			expected: SemVersion{},
+			ok:       false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, ok := NewTiDBSemVersion(tc.input)
+			assert.Equal(t, tc.ok, ok, "ok mismatch")
+			if tc.ok {
+				assert.Equal(t, tc.expected, actual, "version mismatch")
+			}
+		})
+	}
+}

--- a/pkg/util/version_test.go
+++ b/pkg/util/version_test.go
@@ -73,3 +73,78 @@ func TestNewTiDBSemVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestSemVersionCompare(t *testing.T) {
+	testCases := []struct {
+		name     string
+		version1 SemVersion
+		version2 SemVersion
+		expected int
+	}{
+		{
+			name:     "major version greater",
+			version1: SemVersion{Major: 8, Minor: 0, Patch: 0},
+			version2: SemVersion{Major: 7, Minor: 5, Patch: 10},
+			expected: 1,
+		},
+		{
+			name:     "major version less",
+			version1: SemVersion{Major: 6, Minor: 9, Patch: 9},
+			version2: SemVersion{Major: 7, Minor: 0, Patch: 0},
+			expected: -1,
+		},
+		{
+			name:     "major same, minor greater",
+			version1: SemVersion{Major: 7, Minor: 2, Patch: 0},
+			version2: SemVersion{Major: 7, Minor: 1, Patch: 5},
+			expected: 1,
+		},
+		{
+			name:     "major same, minor less",
+			version1: SemVersion{Major: 7, Minor: 1, Patch: 10},
+			version2: SemVersion{Major: 7, Minor: 2, Patch: 0},
+			expected: -1,
+		},
+		{
+			name:     "major and minor same, patch greater",
+			version1: SemVersion{Major: 7, Minor: 1, Patch: 5},
+			version2: SemVersion{Major: 7, Minor: 1, Patch: 0},
+			expected: 1,
+		},
+		{
+			name:     "major and minor same, patch less",
+			version1: SemVersion{Major: 7, Minor: 1, Patch: 0},
+			version2: SemVersion{Major: 7, Minor: 1, Patch: 1},
+			expected: -1,
+		},
+		{
+			name:     "identical versions",
+			version1: SemVersion{Major: 7, Minor: 1, Patch: 0},
+			version2: SemVersion{Major: 7, Minor: 1, Patch: 0},
+			expected: 0,
+		},
+		{
+			name:     "extreme version differences",
+			version1: SemVersion{Major: 10, Minor: 0, Patch: 0},
+			version2: SemVersion{Major: 1, Minor: 99, Patch: 99},
+			expected: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.version1.Compare(tc.version2)
+			if result != tc.expected {
+				t.Errorf("Expected %v.Compare(%v) = %v, got %v",
+					tc.version1, tc.version2, tc.expected, result)
+			}
+
+			reverseResult := tc.version2.Compare(tc.version1)
+			expectedReverse := -tc.expected
+			if reverseResult != expectedReverse {
+				t.Errorf("Expected %v.Compare(%v) = %v, got %v",
+					tc.version2, tc.version1, expectedReverse, reverseResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Issue Number: #187 

According to [System Variables | TiDB Docs](https://docs.pingcap.com/tidb/stable/system-variables#variable-reference), set TiDB QueryTuningVars only when connected to TiDB(>=7.1.0). 

It's still a rough comparison to quickly fix the compatibility issue.