### PR TITLE
feat: add automatic connection refresh for TPC-C workload

### DIFF
--- a/cmd/go-tpc/tpcc.go
+++ b/cmd/go-tpc/tpcc.go
@@ -46,6 +46,13 @@ func executeTpcc(action string) {
 	openDB()
 	defer closeDB()
 
+	// Set a reasonable connection max lifetime when auto-refresh is enabled
+	// This ensures connections are actually closed and not just returned to pool
+	if tpccConfig.ConnRefreshInterval > 0 {
+		globalDB.SetConnMaxLifetime(tpccConfig.ConnRefreshInterval)
+		fmt.Printf("Auto-setting connection max lifetime to %v (refresh interval)\n", tpccConfig.ConnRefreshInterval)
+	}
+
 	tpccConfig.OutputStyle = outputStyle
 	tpccConfig.Driver = driver
 	tpccConfig.DBName = dbName
@@ -116,6 +123,7 @@ func registerTpcc(root *cobra.Command) {
 	cmdRun.PersistentFlags().BoolVar(&tpccConfig.Wait, "wait", false, "including keying & thinking time described on TPC-C Standard Specification")
 	cmdRun.PersistentFlags().DurationVar(&tpccConfig.MaxMeasureLatency, "max-measure-latency", measurement.DefaultMaxLatency, "max measure latency in millisecond")
 	cmdRun.PersistentFlags().IntSliceVar(&tpccConfig.Weight, "weight", []int{45, 43, 4, 4, 4}, "Weight for NewOrder, Payment, OrderStatus, Delivery, StockLevel")
+	cmdRun.Flags().DurationVar(&tpccConfig.ConnRefreshInterval, "conn-refresh-interval", 0, "automatically refresh connections every interval to balance traffic across new replicas (0 = disabled)")
 
 	var cmdCleanup = &cobra.Command{
 		Use:   "cleanup",


### PR DESCRIPTION
The automatic connection refresh feature enables TPC-C workloads to periodically refresh database connections to ensure load balancing across newly added TiDB replicas. This feature is particularly useful in dynamic environments where TiDB nodes are scaled up during operation.
