### PR TITLE
feat(ch): ensure revenue1 view creation for CSV data ingestion

### DIFF
--- a/ch/workload.go
+++ b/ch/workload.go
@@ -352,5 +352,12 @@ func (w *Workloader) FinishPlanReplayerDump() error {
 }
 
 func (w *Workloader) Exec(sql string) error {
-	return nil
+	ctx := context.Background()
+	s := &chState{
+		TpcState: workload.NewTpcState(ctx, w.db),
+	}
+	defer s.Conn.Close()
+
+	_, err := s.Conn.ExecContext(ctx, sql)
+	return err
 }


### PR DESCRIPTION
CH benchmark requires the revenue1 view for analytical queries. During normal prepare flow, this view is created in prepareView() method.

However, when using CSV data ingestion, the prepare stage is skipped and the view won't exist. So we create it here when action is "run" to ensure the view is available regardless of how data was loaded.